### PR TITLE
fix lite-apiserver RequestCacheController.listRequestMap

### DIFF
--- a/pkg/lite-apiserver/proxy/proxy.go
+++ b/pkg/lite-apiserver/proxy/proxy.go
@@ -218,8 +218,8 @@ func (p *EdgeReverseProxy) handlerError(rw http.ResponseWriter, req *http.Reques
 }
 
 func (p *EdgeReverseProxy) filterErrorToIgnore(err error) bool {
-	// ignore watch error
-	if p.watch {
+	// ignore those requests that do not need cache
+	if !p.needCache {
 		return true
 	}
 


### PR DESCRIPTION
1. Replace lite-apiserver RequestCacheController.listRequestMap structure with `map[string]*holder` since current holder slice structure is useless.
2. update filterErrorToIgnore to filter those requests that do not need cache.
3. addListRequest update list request when there already exists.
Signed-off-by: duyanghao <1294057873@qq.com>