### PR TITLE
add node controller for DeploymentGridController

### DIFF
--- a/pkg/application-grid-controller/controller/controller_ref_manager.go
+++ b/pkg/application-grid-controller/controller/controller_ref_manager.go
@@ -148,7 +148,7 @@ func (m *BaseControllerRefManager) ClaimObject(obj metav1.Object, match func(met
 			return false, nil
 		}
 		if err := release(obj); err != nil {
-			// If the pod no longer exists, ignore the error.
+			// If the object no longer exists, ignore the error.
 			if errors.IsNotFound(err) {
 				return false, nil
 			}
@@ -171,7 +171,7 @@ func (m *BaseControllerRefManager) ClaimObject(obj metav1.Object, match func(met
 	}
 	// Selector matches. Try to adopt.
 	if err := adopt(obj); err != nil {
-		// If the pod no longer exists, ignore the error.
+		// If the object no longer exists, ignore the error.
 		if errors.IsNotFound(err) {
 			return false, nil
 		}

--- a/pkg/application-grid-controller/controller/deployment/deployment.go
+++ b/pkg/application-grid-controller/controller/deployment/deployment.go
@@ -48,24 +48,24 @@ func (dgc *DeploymentGridController) addDeployment(obj interface{}) {
 
 	// If it has a ControllerRef, that's all that matters.
 	if controllerRef := metav1.GetControllerOf(d); controllerRef != nil {
-		g := dgc.resolveControllerRef(d.Namespace, controllerRef)
-		if g == nil {
+		dg := dgc.resolveControllerRef(d.Namespace, controllerRef)
+		if dg == nil {
 			return
 		}
-		klog.V(4).Infof("DeploymentGrid %s added.", g.Name)
-		dgc.enqueueDeploymentGrid(g)
+		klog.V(4).Infof("DeploymentGrid %s added.", dg.Name)
+		dgc.enqueueDeploymentGrid(dg)
 		return
 	}
 
 	// Otherwise, it's an orphan. Get a list of all matching DeploymentGrids and sync
 	// them to see if anyone wants to adopt it.
-	gs := dgc.getGridForDeployment(d)
-	if len(gs) == 0 {
+	dgs := dgc.getGridForDeployment(d)
+	if len(dgs) == 0 {
 		return
 	}
 	klog.V(4).Infof("Orphan Deployment %s added.", d.Name)
-	for _, g := range gs {
-		dgc.enqueueDeploymentGrid(g)
+	for _, dg := range dgs {
+		dgc.enqueueDeploymentGrid(dg)
 	}
 }
 
@@ -82,19 +82,19 @@ func (dgc *DeploymentGridController) updateDeployment(oldObj, newObj interface{}
 	controllerRefChanged := !reflect.DeepEqual(curControllerRef, oldControllerRef)
 	if controllerRefChanged && oldControllerRef != nil {
 		// The ControllerRef was changed. Sync the old controller, if any.
-		if g := dgc.resolveControllerRef(oldD.Namespace, oldControllerRef); g != nil {
-			dgc.enqueueDeploymentGrid(g)
+		if dg := dgc.resolveControllerRef(oldD.Namespace, oldControllerRef); dg != nil {
+			dgc.enqueueDeploymentGrid(dg)
 		}
 	}
 
 	// If it has a ControllerRef, that's all that matters.
 	if curControllerRef != nil {
-		g := dgc.resolveControllerRef(curD.Namespace, curControllerRef)
-		if g == nil {
+		dg := dgc.resolveControllerRef(curD.Namespace, curControllerRef)
+		if dg == nil {
 			return
 		}
 		klog.V(4).Infof("DeploymentGrid %s updated.", curD.Name)
-		dgc.enqueueDeploymentGrid(g)
+		dgc.enqueueDeploymentGrid(dg)
 		return
 	}
 
@@ -102,13 +102,13 @@ func (dgc *DeploymentGridController) updateDeployment(oldObj, newObj interface{}
 	// to see if anyone wants to adopt it now.
 	labelChanged := !reflect.DeepEqual(curD.Labels, oldD.Labels)
 	if labelChanged || controllerRefChanged {
-		gs := dgc.getGridForDeployment(curD)
-		if len(gs) == 0 {
+		dgs := dgc.getGridForDeployment(curD)
+		if len(dgs) == 0 {
 			return
 		}
 		klog.V(4).Infof("Orphan Deployment %s updated.", curD.Name)
-		for _, g := range gs {
-			dgc.enqueueDeploymentGrid(g)
+		for _, dg := range dgs {
+			dgc.enqueueDeploymentGrid(dg)
 		}
 	}
 }
@@ -127,20 +127,20 @@ func (dgc *DeploymentGridController) deleteDeployment(obj interface{}) {
 			return
 		}
 	}
+	if !common.IsConcernedObject(d.ObjectMeta) {
+		return
+	}
 	controllerRef := metav1.GetControllerOf(d)
 	if controllerRef == nil {
 		// No controller should care about orphans being deleted.
 		return
 	}
-	g := dgc.resolveControllerRef(d.Namespace, controllerRef)
-	if g == nil {
-		return
-	}
-	if !common.IsConcernedObject(d.ObjectMeta) {
+	dg := dgc.resolveControllerRef(d.Namespace, controllerRef)
+	if dg == nil {
 		return
 	}
 	klog.V(4).Infof("Deployment %s deleted.", d.Name)
-	dgc.enqueueDeploymentGrid(g)
+	dgc.enqueueDeploymentGrid(dg)
 }
 
 func (dgc *DeploymentGridController) resolveControllerRef(namespace string, controllerRef *metav1.OwnerReference) *crdv1.DeploymentGrid {
@@ -149,16 +149,16 @@ func (dgc *DeploymentGridController) resolveControllerRef(namespace string, cont
 	if controllerRef.Kind != util.ControllerKind.Kind {
 		return nil
 	}
-	d, err := dgc.dpGridLister.DeploymentGrids(namespace).Get(controllerRef.Name)
+	dg, err := dgc.dpGridLister.DeploymentGrids(namespace).Get(controllerRef.Name)
 	if err != nil {
 		return nil
 	}
-	if d.UID != controllerRef.UID {
+	if dg.UID != controllerRef.UID {
 		// The controller we found with this Name is not the same one that the
 		// ControllerRef points to.
 		return nil
 	}
-	return d
+	return dg
 }
 
 func (dgc *DeploymentGridController) getGridForDeployment(d *appsv1.Deployment) []*crdv1.DeploymentGrid {
@@ -172,8 +172,8 @@ func (dgc *DeploymentGridController) getGridForDeployment(d *appsv1.Deployment) 
 	}
 
 	var deploymentGrids []*crdv1.DeploymentGrid
-	for _, g := range dgList {
-		selector, err := common.GetDefaultSelector(g.Name)
+	for _, dg := range dgList {
+		selector, err := common.GetDefaultSelector(dg.Name)
 		if err != nil {
 			return nil
 		}
@@ -181,7 +181,7 @@ func (dgc *DeploymentGridController) getGridForDeployment(d *appsv1.Deployment) 
 		if !selector.Matches(labels.Set(d.Labels)) {
 			continue
 		}
-		deploymentGrids = append(deploymentGrids, g)
+		deploymentGrids = append(deploymentGrids, dg)
 	}
 
 	if len(deploymentGrids) == 0 {
@@ -191,7 +191,7 @@ func (dgc *DeploymentGridController) getGridForDeployment(d *appsv1.Deployment) 
 	if len(deploymentGrids) > 1 {
 		// ControllerRef will ensure we don't do anything crazy, but more than one
 		// item in this list nevertheless constitutes user error.
-		klog.V(4).Infof("user error! more than one deployment is selecting deployment %s/%s with labels: %#v, returning %s/%s",
+		klog.V(4).Infof("user error! deployment %s/%s with labels: %#v selects more than one deploymentGrid, returning %s/%s",
 			d.Namespace, d.Name, d.Labels, deploymentGrids[0].Namespace, deploymentGrids[0].Name)
 	}
 	return deploymentGrids

--- a/pkg/application-grid-controller/controller/deployment/deployment.go
+++ b/pkg/application-grid-controller/controller/deployment/deployment.go
@@ -123,7 +123,7 @@ func (dgc *DeploymentGridController) deleteDeployment(obj interface{}) {
 		}
 		d, ok = tombstone.Obj.(*appsv1.Deployment)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Deployment %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object is not a deployment %#v", obj))
 			return
 		}
 	}

--- a/pkg/application-grid-controller/controller/deployment/node.go
+++ b/pkg/application-grid-controller/controller/deployment/node.go
@@ -16,14 +16,93 @@ limitations under the License.
 
 package deployment
 
-func (dgc *DeploymentGridController) addNode(obj interface{}) {
+import (
+	"fmt"
+	crdv1 "github.com/superedge/superedge/pkg/application-grid-controller/apis/superedge.io/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	"reflect"
+)
 
+func (dgc *DeploymentGridController) addNode(obj interface{}) {
+	node := obj.(*v1.Node)
+	if node.DeletionTimestamp != nil {
+		// On a restart of the controller manager, it's possible for an object to
+		// show up in a state that is already pending deletion.
+		dgc.deleteDeployment(node)
+		return
+	}
+	gs := dgc.getGridForNode(node)
+	if len(gs) == 0 {
+		return
+	}
+	klog.V(4).Infof("Node %s added.", node.Name)
+	for _, g := range gs {
+		dgc.enqueueDeploymentGrid(g)
+	}
 }
 
 func (dgc *DeploymentGridController) updateNode(oldObj, newObj interface{}) {
-
+	oldNode := oldObj.(*v1.Node)
+	curNode := newObj.(*v1.Node)
+	labelChanged := !reflect.DeepEqual(curNode.Labels, oldNode.Labels)
+	// Only handles nodes whose label has changed.
+	if labelChanged {
+		gs := dgc.getGridForNode(curNode)
+		if len(gs) == 0 {
+			return
+		}
+		klog.V(4).Infof("Node %s updated.", curNode.Name)
+		for _, g := range gs {
+			dgc.enqueueDeploymentGrid(g)
+		}
+	}
 }
 
 func (dgc *DeploymentGridController) deleteNode(obj interface{}) {
+	node, ok := obj.(*v1.Node)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			return
+		}
+		node, ok = tombstone.Obj.(*v1.Node)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("Tombstone contained object is not a node %#v", obj))
+			return
+		}
+	}
+	gs := dgc.getGridForNode(node)
+	if len(gs) == 0 {
+		return
+	}
+	klog.V(4).Infof("Node %s deleted.", node.Name)
+	for _, g := range gs {
+		dgc.enqueueDeploymentGrid(g)
+	}
+}
 
+// getGridForNode get deploymentGrids those gridUniqKey exists in node labels.
+func (dgc *DeploymentGridController) getGridForNode(node *v1.Node) []*crdv1.DeploymentGrid {
+	if len(node.Labels) == 0 {
+		return nil
+	}
+	dgList, err := dgc.dpGridLister.DeploymentGrids("").List(labels.Everything())
+	if err != nil {
+		return nil
+	}
+	var deploymentGrids []*crdv1.DeploymentGrid
+	for _, g := range dgList {
+		if _, exist := node.Labels[g.Spec.GridUniqKey]; exist {
+			deploymentGrids = append(deploymentGrids, g)
+		}
+	}
+	if len(deploymentGrids) == 0 {
+		return nil
+	}
+	return deploymentGrids
 }

--- a/pkg/application-grid-controller/controller/deployment/node.go
+++ b/pkg/application-grid-controller/controller/deployment/node.go
@@ -19,7 +19,7 @@ package deployment
 import (
 	"fmt"
 	crdv1 "github.com/superedge/superedge/pkg/application-grid-controller/apis/superedge.io/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -28,7 +28,7 @@ import (
 )
 
 func (dgc *DeploymentGridController) addNode(obj interface{}) {
-	node := obj.(*v1.Node)
+	node := obj.(*corev1.Node)
 	if node.DeletionTimestamp != nil {
 		// On a restart of the controller manager, it's possible for an object to
 		// show up in a state that is already pending deletion.
@@ -46,8 +46,8 @@ func (dgc *DeploymentGridController) addNode(obj interface{}) {
 }
 
 func (dgc *DeploymentGridController) updateNode(oldObj, newObj interface{}) {
-	oldNode := oldObj.(*v1.Node)
-	curNode := newObj.(*v1.Node)
+	oldNode := oldObj.(*corev1.Node)
+	curNode := newObj.(*corev1.Node)
 	labelChanged := !reflect.DeepEqual(curNode.Labels, oldNode.Labels)
 	// Only handles nodes whose label has changed.
 	if labelChanged {
@@ -63,14 +63,14 @@ func (dgc *DeploymentGridController) updateNode(oldObj, newObj interface{}) {
 }
 
 func (dgc *DeploymentGridController) deleteNode(obj interface{}) {
-	node, ok := obj.(*v1.Node)
+	node, ok := obj.(*corev1.Node)
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
 			return
 		}
-		node, ok = tombstone.Obj.(*v1.Node)
+		node, ok = tombstone.Obj.(*corev1.Node)
 		if !ok {
 			utilruntime.HandleError(fmt.Errorf("Tombstone contained object is not a node %#v", obj))
 			return
@@ -87,7 +87,7 @@ func (dgc *DeploymentGridController) deleteNode(obj interface{}) {
 }
 
 // getGridForNode get deploymentGrids those gridUniqKey exists in node labels.
-func (dgc *DeploymentGridController) getGridForNode(node *v1.Node) []*crdv1.DeploymentGrid {
+func (dgc *DeploymentGridController) getGridForNode(node *corev1.Node) []*crdv1.DeploymentGrid {
 	if len(node.Labels) == 0 {
 		return nil
 	}

--- a/pkg/application-grid-controller/controller/deployment/node.go
+++ b/pkg/application-grid-controller/controller/deployment/node.go
@@ -35,13 +35,13 @@ func (dgc *DeploymentGridController) addNode(obj interface{}) {
 		dgc.deleteDeployment(node)
 		return
 	}
-	gs := dgc.getGridForNode(node)
-	if len(gs) == 0 {
+	dgs := dgc.getGridForNode(node)
+	if len(dgs) == 0 {
 		return
 	}
 	klog.V(4).Infof("Node %s added.", node.Name)
-	for _, g := range gs {
-		dgc.enqueueDeploymentGrid(g)
+	for _, dg := range dgs {
+		dgc.enqueueDeploymentGrid(dg)
 	}
 }
 
@@ -51,13 +51,13 @@ func (dgc *DeploymentGridController) updateNode(oldObj, newObj interface{}) {
 	labelChanged := !reflect.DeepEqual(curNode.Labels, oldNode.Labels)
 	// Only handles nodes whose label has changed.
 	if labelChanged {
-		gs := dgc.getGridForNode(curNode)
-		if len(gs) == 0 {
+		dgs := dgc.getGridForNode(curNode)
+		if len(dgs) == 0 {
 			return
 		}
 		klog.V(4).Infof("Node %s updated.", curNode.Name)
-		for _, g := range gs {
-			dgc.enqueueDeploymentGrid(g)
+		for _, dg := range dgs {
+			dgc.enqueueDeploymentGrid(dg)
 		}
 	}
 }
@@ -76,13 +76,13 @@ func (dgc *DeploymentGridController) deleteNode(obj interface{}) {
 			return
 		}
 	}
-	gs := dgc.getGridForNode(node)
-	if len(gs) == 0 {
+	dgs := dgc.getGridForNode(node)
+	if len(dgs) == 0 {
 		return
 	}
 	klog.V(4).Infof("Node %s deleted.", node.Name)
-	for _, g := range gs {
-		dgc.enqueueDeploymentGrid(g)
+	for _, dg := range dgs {
+		dgc.enqueueDeploymentGrid(dg)
 	}
 }
 
@@ -96,9 +96,9 @@ func (dgc *DeploymentGridController) getGridForNode(node *v1.Node) []*crdv1.Depl
 		return nil
 	}
 	var deploymentGrids []*crdv1.DeploymentGrid
-	for _, g := range dgList {
-		if _, exist := node.Labels[g.Spec.GridUniqKey]; exist {
-			deploymentGrids = append(deploymentGrids, g)
+	for _, dg := range dgList {
+		if _, exist := node.Labels[dg.Spec.GridUniqKey]; exist {
+			deploymentGrids = append(deploymentGrids, dg)
 		}
 	}
 	if len(deploymentGrids) == 0 {

--- a/pkg/application-grid-controller/controller/deployment/sync.go
+++ b/pkg/application-grid-controller/controller/deployment/sync.go
@@ -73,10 +73,6 @@ func (dgc *DeploymentGridController) reconcile(dg *crdv1.DeploymentGrid, dpList 
 
 	for _, v := range gridValues {
 		name := util.GetDeploymentName(dg, v)
-		spec := *dg.Spec.Template.DeepCopy()
-		spec.Template.Spec.NodeSelector = map[string]string{
-			dg.Spec.GridUniqKey: v,
-		}
 
 		dp, found := existedDPsMap[name]
 		if !found {

--- a/pkg/application-grid-controller/controller/deployment/sync.go
+++ b/pkg/application-grid-controller/controller/deployment/sync.go
@@ -31,27 +31,27 @@ import (
 	"github.com/superedge/superedge/pkg/application-grid-controller/controller/deployment/util"
 )
 
-func (dgc *DeploymentGridController) syncStatus(g *crdv1.DeploymentGrid, dpList []*appsv1.Deployment, gridValues []string) error {
+func (dgc *DeploymentGridController) syncStatus(dg *crdv1.DeploymentGrid, dpList []*appsv1.Deployment, gridValues []string) error {
 	wanted := sets.NewString()
 	for _, v := range gridValues {
-		wanted.Insert(util.GetDeploymentName(g, v))
+		wanted.Insert(util.GetDeploymentName(dg, v))
 	}
 
 	states := make(map[string]appsv1.DeploymentStatus)
 	for _, dp := range dpList {
 		if wanted.Has(dp.Name) {
-			states[util.GetGridValueFromName(g, dp.Name)] = dp.Status
+			states[util.GetGridValueFromName(dg, dp.Name)] = dp.Status
 		}
 	}
-	g.Status.States = states
-	_, err := dgc.crdClient.SuperedgeV1().DeploymentGrids(g.Namespace).UpdateStatus(context.TODO(), g, metav1.UpdateOptions{})
+	dg.Status.States = states
+	_, err := dgc.crdClient.SuperedgeV1().DeploymentGrids(dg.Namespace).UpdateStatus(context.TODO(), dg, metav1.UpdateOptions{})
 	if err != nil && errors.IsConflict(err) {
 		return nil
 	}
 	return err
 }
 
-func (dgc *DeploymentGridController) reconcile(g *crdv1.DeploymentGrid, dpList []*appsv1.Deployment, gridValues []string) error {
+func (dgc *DeploymentGridController) reconcile(dg *crdv1.DeploymentGrid, dpList []*appsv1.Deployment, gridValues []string) error {
 	existedDPsMap := make(map[string]*appsv1.Deployment)
 
 	for _, dp := range dpList {
@@ -62,7 +62,7 @@ func (dgc *DeploymentGridController) reconcile(g *crdv1.DeploymentGrid, dpList [
 	for _, v := range gridValues {
 		/* nginx-zone1
 		 */
-		wanted.Insert(util.GetDeploymentName(g, v))
+		wanted.Insert(util.GetDeploymentName(dg, v))
 	}
 
 	var (
@@ -72,19 +72,19 @@ func (dgc *DeploymentGridController) reconcile(g *crdv1.DeploymentGrid, dpList [
 	)
 
 	for _, v := range gridValues {
-		name := util.GetDeploymentName(g, v)
-		spec := *g.Spec.Template.DeepCopy()
+		name := util.GetDeploymentName(dg, v)
+		spec := *dg.Spec.Template.DeepCopy()
 		spec.Template.Spec.NodeSelector = map[string]string{
-			g.Spec.GridUniqKey: v,
+			dg.Spec.GridUniqKey: v,
 		}
 
 		dp, found := existedDPsMap[name]
 		if !found {
-			adds = append(adds, util.CreateDeployment(g, v))
+			adds = append(adds, util.CreateDeployment(dg, v))
 			continue
 		}
 
-		template := util.KeepConsistence(g, dp, v)
+		template := util.KeepConsistence(dg, dp, v)
 		if !apiequality.Semantic.DeepEqual(template, dp) {
 			updates = append(updates, template)
 		} else {
@@ -103,7 +103,7 @@ func (dgc *DeploymentGridController) reconcile(g *crdv1.DeploymentGrid, dpList [
 		return err
 	}
 
-	return dgc.syncStatus(g, updates, gridValues)
+	return dgc.syncStatus(dg, updates, gridValues)
 }
 
 func (dgc *DeploymentGridController) syncDeployment(adds, updates, deletes []*appsv1.Deployment) error {

--- a/pkg/application-grid-controller/controller/deployment/util/deployment_util.go
+++ b/pkg/application-grid-controller/controller/deployment/util/deployment_util.go
@@ -65,7 +65,7 @@ func KeepConsistence(dg *crdv1.DeploymentGrid, dp *appsv1.Deployment, gridValue 
 	copyObj.Labels[common.GridSelectorName] = dg.Name
 	copyObj.Spec.Replicas = dg.Spec.Template.Replicas
 	copyObj.Spec.Selector = dg.Spec.Template.Selector
-	// TODO: this line will cause DeepEqual fails always since actual generated deployment.Spec.Template is differnent with ones of relevant deploymentGrid
+	// TODO: this line will cause DeepEqual fails always since actual generated deployment.Spec.Template is definitely different with ones of relevant deploymentGrid
 	copyObj.Spec.Template = dg.Spec.Template.Template
 	copyObj.Spec.Template.Spec.NodeSelector = map[string]string{
 		dg.Spec.GridUniqKey: gridValue,

--- a/pkg/application-grid-controller/controller/deployment/util/deployment_util.go
+++ b/pkg/application-grid-controller/controller/deployment/util/deployment_util.go
@@ -40,8 +40,8 @@ func GetGridValueFromName(g *crdv1.DeploymentGrid, name string) string {
 func CreateDeployment(g *crdv1.DeploymentGrid, gridValue string) *appsv1.Deployment {
 	dp := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetDeploymentName(g, gridValue),
-			Namespace: g.Namespace,
+			Name:            GetDeploymentName(g, gridValue),
+			Namespace:       g.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(g, ControllerKind)},
 			Labels: map[string]string{
 				common.GridSelectorName: g.Name,

--- a/pkg/application-grid-controller/controller/service/sync.go
+++ b/pkg/application-grid-controller/controller/service/sync.go
@@ -71,9 +71,9 @@ func (sgc *ServiceGridController) syncService(adds, updates, deletes []*corev1.S
 	errCh := make(chan error, totalSize)
 
 	for i := range adds {
-		go func(d *corev1.Service) {
+		go func(svc *corev1.Service) {
 			defer wg.Done()
-			_, err := sgc.kubeClient.CoreV1().Services(d.Namespace).Create(context.TODO(), d, metav1.CreateOptions{})
+			_, err := sgc.kubeClient.CoreV1().Services(svc.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
 			if err != nil {
 				errCh <- err
 			}
@@ -81,9 +81,9 @@ func (sgc *ServiceGridController) syncService(adds, updates, deletes []*corev1.S
 	}
 
 	for i := range updates {
-		go func(d *corev1.Service) {
+		go func(svc *corev1.Service) {
 			defer wg.Done()
-			_, err := sgc.kubeClient.CoreV1().Services(d.Namespace).Update(context.TODO(), d, metav1.UpdateOptions{})
+			_, err := sgc.kubeClient.CoreV1().Services(svc.Namespace).Update(context.TODO(), svc, metav1.UpdateOptions{})
 			if err != nil {
 				errCh <- err
 			}
@@ -91,9 +91,9 @@ func (sgc *ServiceGridController) syncService(adds, updates, deletes []*corev1.S
 	}
 
 	for i := range deletes {
-		go func(d *corev1.Service) {
+		go func(svc *corev1.Service) {
 			defer wg.Done()
-			err := sgc.kubeClient.CoreV1().Services(d.Namespace).Delete(context.TODO(), d.Name, metav1.DeleteOptions{})
+			err := sgc.kubeClient.CoreV1().Services(svc.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
 			if err != nil {
 				errCh <- err
 			}

--- a/pkg/application-grid-controller/controller/service/util/service_util.go
+++ b/pkg/application-grid-controller/controller/service/util/service_util.go
@@ -28,60 +28,61 @@ import (
 
 var ControllerKind = crdv1.SchemeGroupVersion.WithKind("ServiceGrid")
 
-func GetServiceName(g *crdv1.ServiceGrid) string {
-	return strings.Join([]string{g.Name, "svc"}, "-")
+func GetServiceName(sg *crdv1.ServiceGrid) string {
+	return strings.Join([]string{sg.Name, "svc"}, "-")
 }
 
-func CreateService(g *crdv1.ServiceGrid) *corev1.Service {
+func CreateService(sg *crdv1.ServiceGrid) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetServiceName(g),
-			Namespace: g.Namespace,
+			Name:      GetServiceName(sg),
+			Namespace: sg.Namespace,
 			Labels: map[string]string{
-				common.GridSelectorName: g.Name,
+				common.GridSelectorName: sg.Name,
 			},
 			Annotations: make(map[string]string),
 		},
-		Spec: g.Spec.Template,
+		Spec: sg.Spec.Template,
 	}
 
 	keys := make([]string, 1)
-	keys[0] = g.Spec.GridUniqKey
+	keys[0] = sg.Spec.GridUniqKey
 	keyData, _ := json.Marshal(keys)
 	svc.Annotations[common.TopologyAnnotationsKey] = string(keyData)
 
 	return svc
 }
 
-func KeepConsistence(g *crdv1.ServiceGrid, svc *corev1.Service) *corev1.Service {
+func KeepConsistence(sg *crdv1.ServiceGrid, svc *corev1.Service) *corev1.Service {
 	copyObj := svc.DeepCopy()
 	if copyObj.Labels == nil {
 		copyObj.Labels = make(map[string]string)
 	}
-	copyObj.Labels[common.GridSelectorName] = g.Name
+	copyObj.Labels[common.GridSelectorName] = sg.Name
 
 	if copyObj.Annotations == nil {
 		copyObj.Annotations = make(map[string]string)
 	}
 
 	keys := make([]string, 1)
-	keys[0] = g.Spec.GridUniqKey
+	keys[0] = sg.Spec.GridUniqKey
 	keyData, _ := json.Marshal(keys)
 	copyObj.Annotations[common.TopologyAnnotationsKey] = string(keyData)
 
 	var oldServiceNameNodePort = make(map[string]int32)
 	var newServiceNameNodePort = make(map[string]int32)
-	if g.Spec.Template.Type == corev1.ServiceTypeNodePort && copyObj.Spec.Type == corev1.ServiceTypeNodePort {
+	if sg.Spec.Template.Type == corev1.ServiceTypeNodePort && copyObj.Spec.Type == corev1.ServiceTypeNodePort {
 		for _, port := range copyObj.Spec.Ports {
 			oldServiceNameNodePort[port.Name] = port.NodePort
 		}
-		for _, port := range g.Spec.Template.Ports {
+		for _, port := range sg.Spec.Template.Ports {
 			newServiceNameNodePort[port.Name] = port.NodePort
 		}
 	}
 
-	copyObj.Spec.Ports = g.Spec.Template.Ports
-	if g.Spec.Template.Type == corev1.ServiceTypeNodePort && copyObj.Spec.Type == corev1.ServiceTypeNodePort {
+	copyObj.Spec.Selector = sg.Spec.Template.Selector
+	copyObj.Spec.Ports = sg.Spec.Template.Ports
+	if sg.Spec.Template.Type == corev1.ServiceTypeNodePort && copyObj.Spec.Type == corev1.ServiceTypeNodePort {
 		for k, port := range copyObj.Spec.Ports {
 			if _, ok := oldServiceNameNodePort[port.Name]; ok {
 				if newServiceNameNodePort[port.Name] == 0 && oldServiceNameNodePort[port.Name] != 0 {

--- a/pkg/application-grid-controller/controller/service/util/service_util.go
+++ b/pkg/application-grid-controller/controller/service/util/service_util.go
@@ -26,10 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//var (
-//	ServiceTopologyEnabled = utilfeature.DefaultMutableFeatureGate.Enabled(common.ServiceTopology) &&
-//		utilfeature.DefaultMutableFeatureGate.Enabled(common.EndpointSlice)
-//)
+var ControllerKind = crdv1.SchemeGroupVersion.WithKind("ServiceGrid")
 
 func GetServiceName(g *crdv1.ServiceGrid) string {
 	return strings.Join([]string{g.Name, "svc"}, "-")
@@ -48,14 +45,10 @@ func CreateService(g *crdv1.ServiceGrid) *corev1.Service {
 		Spec: g.Spec.Template,
 	}
 
-	//if ServiceTopologyEnabled {
-	//	svc.Spec.TopologyKeys = append(svc.Spec.TopologyKeys, g.Spec.GridUniqKey)
-	//} else {
 	keys := make([]string, 1)
 	keys[0] = g.Spec.GridUniqKey
 	keyData, _ := json.Marshal(keys)
 	svc.Annotations[common.TopologyAnnotationsKey] = string(keyData)
-	//}
 
 	return svc
 }
@@ -71,14 +64,11 @@ func KeepConsistence(g *crdv1.ServiceGrid, svc *corev1.Service) *corev1.Service 
 		copyObj.Annotations = make(map[string]string)
 	}
 
-	//if ServiceTopologyEnabled {
-	//	copyObj.Spec.TopologyKeys = []string{g.Spec.GridUniqKey}
-	//} else {
 	keys := make([]string, 1)
 	keys[0] = g.Spec.GridUniqKey
 	keyData, _ := json.Marshal(keys)
 	copyObj.Annotations[common.TopologyAnnotationsKey] = string(keyData)
-	//}
+
 	var oldServiceNameNodePort = make(map[string]int32)
 	var newServiceNameNodePort = make(map[string]int32)
 	if g.Spec.Template.Type == corev1.ServiceTypeNodePort && copyObj.Spec.Type == corev1.ServiceTypeNodePort {


### PR DESCRIPTION
This PR aims to do following things:
1. Add the node controller logic for DeploymentGridController to avoid the loss of the node changed detection.
2. Fix some informal spelling mistakes
3. Add serviceGrid KeepConsistence Selector and deploymentGrid KeepConsistence TODO comments
4. Fix serviceGrid.KeepConsistence port.Name empty bug
Signed-off-by: duyanghao <1294057873@qq.com>