### PR TITLE
edgeadm: fix the wrong tip

### DIFF
--- a/docs/installation/tutorial_CN.md
+++ b/docs/installation/tutorial_CN.md
@@ -6,7 +6,7 @@
 
 - build: `make build`
 
-- build some cmd: `make build BINS="lite-apiserver edgeadm`
+- build some cmd: `make build BINS="lite-apiserver edgeadm"`
 
 - build multi arch cmd: `make build.multiarch BINS="lite-apiserver edgeadm" PLATFORMS="linux_amd64 linux_arm64"`
 

--- a/pkg/edgeadm/cmd/change/change.go
+++ b/pkg/edgeadm/cmd/change/change.go
@@ -112,6 +112,4 @@ func (c *changeAction) runChange() error {
 	default:
 		return fmt.Errorf("Not support %s change to edge cluster\n", c.deployName)
 	}
-
-	return nil
 }

--- a/pkg/util/kubeclient/client.go
+++ b/pkg/util/kubeclient/client.go
@@ -54,7 +54,7 @@ func GetClientSet(kubeconfigFile string) (*kubernetes.Clientset, error) {
 	}
 
 	if kubeconfigFile == "" {
-		return nil, fmt.Errorf("kubeconfig nil, Please appoint --kubeconfig, KUBECONFIG or ~/kube/config")
+		return nil, fmt.Errorf("kubeconfig nil, Please appoint --kubeconfig, KUBECONFIG or ~/.kube/config")
 	}
 
 	os.Setenv("KUBECONF", kubeconfigFile)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**

Fixes

**What this PR does**:

The original tips of nil kubeconfig "kubeconfig nil, Please appoint --kubeconfig, KUBECONFIG or ~/kube/config" should be "kubeconfig nil, Please appoint --kubeconfig, KUBECONFIG or ~/.kube/config"

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

