### PR TITLE
Fix kubectl cp connection cannot be disconnected

### DIFF
--- a/pkg/tunnel/proxy/https/httpsmng/httpsclient.go
+++ b/pkg/tunnel/proxy/https/httpsmng/httpsclient.go
@@ -48,13 +48,9 @@ func Request(msg *proto.StreamMsg) {
 	bodyMsg := HttpsMsg{
 		StatusCode:  resp.StatusCode,
 		HttpsStatus: util.CONNECTED,
-		Header:      make(map[string]string),
+		Header:      make(http.Header),
 	}
-	for k, v := range resp.Header {
-		for _, vv := range v {
-			bodyMsg.Header[k] = vv
-		}
-	}
+	bodyMsg.Header = resp.Header
 	msgData := bodyMsg.Serialization()
 	if len(msgData) == 0 {
 		klog.Errorf("traceid = %s httpsclient httpsmsg serialization failed", msg.Topic)
@@ -104,9 +100,7 @@ func getHttpConn(msg *proto.StreamMsg) (net.Conn, error) {
 		klog.Errorf("traceid = %s httpsclient get request fail err = %v", msg.Topic, err)
 		return nil, err
 	}
-	for k, v := range requestMsg.Header {
-		request.Header.Add(k, v)
-	}
+	request.Header = requestMsg.Header
 	conn, err := tls.Dial("tcp", request.Host, &tls.Config{
 		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: true,

--- a/pkg/tunnel/proxy/https/httpsmng/httpsmsg.go
+++ b/pkg/tunnel/proxy/https/httpsmng/httpsmsg.go
@@ -19,14 +19,15 @@ package httpsmng
 import (
 	"encoding/json"
 	"k8s.io/klog"
+	"net/http"
 )
 
 type HttpsMsg struct {
-	StatusCode  int               `json:"status_code"`
-	HttpsStatus string            `json:"https_status"`
-	HttpBody    []byte            `json:"http_body"`
-	Header      map[string]string `json:"header"`
-	Method      string            `json:"method"`
+	StatusCode  int         `json:"status_code"`
+	HttpsStatus string      `json:"https_status"`
+	HttpBody    []byte      `json:"http_body"`
+	Header      http.Header `json:"header"`
+	Method      string      `json:"method"`
 }
 
 func (msg *HttpsMsg) Serialization() []byte {

--- a/pkg/tunnel/proxy/https/httpsmng/httpsserver.go
+++ b/pkg/tunnel/proxy/https/httpsmng/httpsserver.go
@@ -87,15 +87,13 @@ func (serverHandler *ServerHandler) ServeHTTP(writer http.ResponseWriter, reques
 	}
 	httpmsg := &HttpsMsg{
 		HttpsStatus: util.CONNECTING,
-		Header:      make(map[string]string),
+		Header:      make(map[string][]string),
 		Method:      request.Method,
 		HttpBody:    requestBody,
 	}
-	for k, v := range request.Header {
-		for _, vv := range v {
-			httpmsg.Header[k] = vv
-		}
-	}
+
+	httpmsg.Header = request.Header
+
 	bmsg := httpmsg.Serialization()
 	if len(bmsg) == 0 {
 		klog.Errorf("traceid = %s httpsmsg serialization failed err = %v req = %v serverName = %s", uid, err, request, request.TLS.ServerName)
@@ -142,7 +140,9 @@ func (serverHandler *ServerHandler) ServeHTTP(writer http.ResponseWriter, reques
 
 func handleServerHttp(rmsg *HttpsMsg, writer http.ResponseWriter, request *http.Request, node context.Node, conn context.Conn) {
 	for k, v := range rmsg.Header {
-		writer.Header().Add(k, v)
+		for _, vv := range v {
+			writer.Header().Add(k, vv)
+		}
 	}
 	flusher, ok := writer.(http.Flusher)
 	if ok {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
/kind bug
**What this PR does**:
Tunnel edge does not select channel.k8s.io when negotiating with kubelet's httpstream server because there are known bugs  http://issues.k8s.io/13394 and http://issues.k8s.io/13395 in channel.k8s.io
**Which issue(s) this PR fixes**:

Fixes #
The tunnel cloud forwards all the X-Stream-Protocol-Version protocols (v4.channel.k8s.io v3.channel.k8s.io v2.channel.k8s.io channel.k8s.io) in the header to the tunnel edge instead of only channel.k8s.io

**Special notes for your reviewer**:

