### PR TITLE
edgeadm: Add edgeadm add-on apps deletion feature

### DIFF
--- a/cmd/edgeadm/app/server.go
+++ b/cmd/edgeadm/app/server.go
@@ -27,6 +27,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 
 	"github.com/superedge/superedge/pkg/edgeadm/cmd"
+	"github.com/superedge/superedge/pkg/edgeadm/cmd/addon"
 	"github.com/superedge/superedge/pkg/edgeadm/cmd/change"
 	"github.com/superedge/superedge/pkg/edgeadm/cmd/revert"
 	"github.com/superedge/superedge/pkg/edgeadm/constant"
@@ -67,6 +68,8 @@ func NewEdgeadmCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds.AddCommand(kubeadm.NewJoinCMD(os.Stdout, &edgeadmConf))
 	cmds.AddCommand(kubeadm.NewCmdToken(os.Stdout, os.Stdout))
 	cmds.AddCommand(kubeadm.NewResetCMD(os.Stdin, os.Stdout, &edgeadmConf))
+	cmds.AddCommand(addon.NewAddonCMD())
+	cmds.AddCommand(addon.NewDetachCMD())
 
 	return cmds
 }

--- a/pkg/edgeadm/cmd/addon/addon.go
+++ b/pkg/edgeadm/cmd/addon/addon.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
+
+	"github.com/superedge/superedge/pkg/util/kubeclient"
+)
+
+type addonAction struct {
+	clientSet        *kubernetes.Clientset
+	flags            *pflag.FlagSet
+	manifestDir      string
+	caKeyFile        string
+	caCertFile       string
+	masterPublicAddr string
+	certSANs         []string
+}
+
+func NewAddonCMD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "addon",
+		Short: "Addon apps to Kubernetes cluster",
+		Long:  cmdutil.MacroCommandLongDescription,
+	}
+	cmd.AddCommand(NewInstallEdgeAppsCMD())
+	return cmd
+}
+
+func NewDetachCMD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "detach",
+		Short: "Detach apps from Kubernetes cluster",
+		Long:  cmdutil.MacroCommandLongDescription,
+	}
+	cmd.AddCommand(NewDetachEdgeAppsCMD())
+	return cmd
+}
+
+func (a *addonAction) complete() error {
+	configPath, err := a.flags.GetString("kubeconfig")
+	if err != nil {
+		klog.Errorf("Get kubeconfig flags error: %v", err)
+	}
+
+	a.clientSet, err = kubeclient.GetClientSet(configPath)
+	if err != nil {
+		klog.Errorf("GetClientSet error: %v", err)
+		return err
+	}
+	if a.clientSet == nil {
+		return fmt.Errorf("Please set kubeconfig value!\n")
+	}
+
+	return nil
+}

--- a/pkg/edgeadm/cmd/addon/edgeapps.go
+++ b/pkg/edgeadm/cmd/addon/edgeapps.go
@@ -1,0 +1,87 @@
+package addon
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	"github.com/superedge/superedge/pkg/edgeadm/common"
+	"github.com/superedge/superedge/pkg/edgeadm/constant"
+	"github.com/superedge/superedge/pkg/util"
+)
+
+func NewInstallEdgeAppsCMD() *cobra.Command {
+	action := addonAction{}
+	cmd := &cobra.Command{
+		Use:   "edge-apps",
+		Short: "Addon edge apps to Kubernetes cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := action.complete(); err != nil {
+				util.OutPutMessage(err.Error())
+				return
+			}
+
+			if err := action.runAddon(); err != nil {
+				util.OutPutMessage(err.Error())
+				return
+			}
+		},
+	}
+	action.flags = cmd.Flags()
+	cmd.Flags().StringVar(&action.manifestDir, "manifest-dir", "",
+		"Manifests document of edge kubernetes cluster.")
+
+	cmd.Flags().StringVar(&action.caCertFile, "ca.cert", constant.KubeadmCertPath,
+		"The root certificate file for cluster.")
+
+	cmd.Flags().StringVar(&action.caKeyFile, "ca.key", constant.KubeadmKeyPath,
+		"The root certificate key file for cluster.")
+	cmd.Flags().StringVar(&action.masterPublicAddr, "masterPublicAddr", "",
+		"The public IP for control plane")
+	cmd.Flags().StringArrayVar(&action.certSANs, "certSANs", []string{""},
+		"The cert SAN")
+	return cmd
+}
+
+func NewDetachEdgeAppsCMD() *cobra.Command {
+	action := addonAction{}
+	cmd := &cobra.Command{
+		Use:   "edge-apps",
+		Short: "Delete edge apps to Kubernetes cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := action.complete(); err != nil {
+				util.OutPutMessage(err.Error())
+				return
+			}
+
+			if err := action.runDetach(); err != nil {
+				util.OutPutMessage(err.Error())
+				return
+			}
+		},
+	}
+	action.flags = cmd.Flags()
+	cmd.Flags().StringVar(&action.manifestDir, "manifest-dir", "",
+		"Manifests document of edge kubernetes cluster.")
+
+	cmd.Flags().StringVar(&action.caCertFile, "ca.cert", constant.KubeadmCertPath,
+		"The root certificate file for cluster. (default \"/etc/kubernetes/pki/ca.crt\")")
+
+	cmd.Flags().StringVar(&action.caKeyFile, "ca.key", constant.KubeadmKeyPath,
+		"The root certificate key file for cluster. (default \"/etc/kubernetes/pki/ca.key\")")
+	cmd.Flags().StringVar(&action.masterPublicAddr, "masterPublicAddr", "",
+		"The public IP for control plane")
+	cmd.Flags().StringArrayVar(&action.certSANs, "certSANs", []string{""},
+		"The cert SAN")
+
+	return cmd
+}
+
+func (a *addonAction) runAddon() error {
+	klog.Info("Start install addon apps to your original cluster")
+	return common.DeployEdgeAPPS(a.clientSet, a.manifestDir, a.caCertFile, a.caKeyFile, a.masterPublicAddr, a.certSANs)
+}
+
+func (a *addonAction) runDetach() error {
+	klog.Info("Start install addon apps to your original cluster")
+	return common.DeleteEdgeAPPS(a.clientSet, a.manifestDir, a.caCertFile, a.caKeyFile, a.masterPublicAddr, a.certSANs)
+}

--- a/pkg/edgeadm/common/deploy_lite_apiserver.go
+++ b/pkg/edgeadm/common/deploy_lite_apiserver.go
@@ -128,3 +128,19 @@ func CreateLiteApiServerCert(clientSet kubernetes.Interface, manifestsDir, caCer
 
 	return nil
 }
+
+func DeleteLiteApiServerCert(clientSet kubernetes.Interface) error {
+	if err := clientSet.RbacV1().Roles(constant.NamespaceEdgeSystem).Delete(
+		context.TODO(), "lite-apiserver", metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+	if err := clientSet.RbacV1().RoleBindings(constant.NamespaceEdgeSystem).Delete(
+		context.TODO(), "lite-apiserver", metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	clientSet.CoreV1().ConfigMaps(constant.NamespaceEdgeSystem).Delete(
+		context.TODO(), constant.EdgeCertCM, metav1.DeleteOptions{})
+
+	return nil
+}

--- a/pkg/edgeadm/common/deploy_service_group.go
+++ b/pkg/edgeadm/common/deploy_service_group.go
@@ -34,30 +34,43 @@ import (
 )
 
 func DeployServiceGroup(clientSet kubernetes.Interface, manifestsDir string) error {
-	advertiseAddress, err := GetKubeAPIServerAddr(clientSet)
+	gridWrapper, gridController, option, err := getServiceGroupResource(clientSet, manifestsDir)
 	if err != nil {
-		klog.Errorf("Get Kube-api-server add and port, error: %v", err)
 		return err
 	}
 
-	option := map[string]interface{}{
-		"AdvertiseAddress": advertiseAddress,
-	}
-	userGridWrapper := filepath.Join(manifestsDir, manifests.APP_APPLICATION_GRID_WRAPPER)
-	gridWrapper := ReadYaml(userGridWrapper, manifests.ApplicationGridWrapperYaml)
 	if err := kubeclient.CreateResourceWithFile(clientSet, gridWrapper, option); err != nil {
 		return err
 	}
 	klog.V(4).Infof("Deploy %s success!", manifests.APP_APPLICATION_GRID_WRAPPER)
 
-	userGridController := filepath.Join(manifestsDir, manifests.APP_APPLICATION_GRID_CONTROLLER)
-	gridController := ReadYaml(userGridController, manifests.ApplicationGridControllerYaml)
 	if err := CreateByYamlFile(clientSet, gridController); err != nil {
 		klog.Errorf("Deploy %s error: %s", manifests.APP_APPLICATION_GRID_CONTROLLER, err)
 		return err
 	}
 
 	klog.V(4).Infof("Create %s success!", manifests.APP_APPLICATION_GRID_CONTROLLER)
+
+	return nil
+}
+
+func DeleteServiceGroup(clientSet kubernetes.Interface, manifestsDir string) error {
+	gridWrapper, gridController, option, err := getServiceGroupResource(clientSet, manifestsDir)
+	if err != nil {
+		return err
+	}
+
+	if err := kubeclient.DeleteResourceWithFile(clientSet, gridWrapper, option); err != nil {
+		return err
+	}
+	klog.V(4).Infof("Delete %s success!", manifests.APP_APPLICATION_GRID_WRAPPER)
+
+	if err := DeleteByYamlFile(clientSet, gridController); err != nil {
+		klog.Errorf("Delete %s error: %s", manifests.APP_APPLICATION_GRID_CONTROLLER, err)
+		return err
+	}
+
+	klog.V(4).Infof("Delete %s success!", manifests.APP_APPLICATION_GRID_CONTROLLER)
 
 	return nil
 }
@@ -89,4 +102,22 @@ func GetKubeAPIServerAddr(clientSet kubernetes.Interface) (string, error) {
 		}
 	}
 	return "", errors.New("Get kube-api server addr nil\n")
+}
+
+func getServiceGroupResource(clientSet kubernetes.Interface, manifestsDir string) (string, string, interface{}, error) {
+	advertiseAddress, err := GetKubeAPIServerAddr(clientSet)
+	if err != nil {
+		klog.Errorf("Get Kube-api-server add and port, error: %v", err)
+		return "", "", nil, err
+	}
+
+	option := map[string]interface{}{
+		"AdvertiseAddress": advertiseAddress,
+	}
+	userGridWrapper := filepath.Join(manifestsDir, manifests.APP_APPLICATION_GRID_WRAPPER)
+	gridWrapper := ReadYaml(userGridWrapper, manifests.ApplicationGridWrapperYaml)
+
+	userGridController := filepath.Join(manifestsDir, manifests.APP_APPLICATION_GRID_CONTROLLER)
+	gridController := ReadYaml(userGridController, manifests.ApplicationGridControllerYaml)
+	return gridWrapper, gridController, option, err
 }

--- a/pkg/edgeadm/common/deploy_tunnel.go
+++ b/pkg/edgeadm/common/deploy_tunnel.go
@@ -62,47 +62,10 @@ func DeployTunnelAddon(client *kubernetes.Clientset, manifestsDir, caCertFile, c
 }
 
 func DeployTunnelCloud(clientSet kubernetes.Interface, manifestsDir, caCertFile, caKeyFile, tunnelCloudToken string, certSANs []string) error {
-	nodes, err := clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	tunnelCloudYaml, option, err := getTunnelCloudResource(clientSet, manifestsDir, caCertFile, caKeyFile, tunnelCloudToken, certSANs)
 	if err != nil {
 		return err
 	}
-
-	var masterIPs []string
-	for _, node := range nodes.Items {
-		if _, ok := node.Labels[constant.KubernetesDefaultRoleLabel]; ok {
-			for _, address := range node.Status.Addresses {
-				if address.Type == v1.NodeInternalIP || address.Type == v1.NodeExternalIP {
-					masterIPs = append(masterIPs, address.Address)
-				}
-			}
-		}
-	}
-
-	dns := []string{
-		"tunnel.cloud.io",
-		"tunnelcloud.superedge.io",
-	}
-	dns = append(dns, certSANs...)
-	serviceCert, serviceKey, err := GetServiceCert("TunnelCloudService", caCertFile, caKeyFile, dns, masterIPs)
-	if err != nil {
-		return err
-	}
-
-	tunnelProxyServerCrt, tunnelProxyServerKey, err := GetServiceCert("TunnelCloudClient", caCertFile, caKeyFile, []string{}, []string{})
-	if err != nil {
-		return err
-	}
-
-	option := map[string]interface{}{
-		"TunnelCloudEdgeToken":                tunnelCloudToken,
-		"TunnelPersistentConnectionServerKey": base64.StdEncoding.EncodeToString(serviceKey),
-		"TunnelPersistentConnectionServerCrt": base64.StdEncoding.EncodeToString(serviceCert),
-		"TunnelProxyServerKey":                base64.StdEncoding.EncodeToString(tunnelProxyServerKey),
-		"TunnelProxyServerCrt":                base64.StdEncoding.EncodeToString(tunnelProxyServerCrt),
-	}
-
-	userManifests := filepath.Join(manifestsDir, manifests.APP_TUNNEL_CLOUD)
-	tunnelCloudYaml := ReadYaml(userManifests, manifests.TunnelCloudYaml)
 	err = kubeclient.CreateResourceWithFile(clientSet, tunnelCloudYaml, option)
 	if err != nil {
 		return err
@@ -137,20 +100,154 @@ func GetTunnelCloudPort(clientSet kubernetes.Interface) (int32, error) {
 func DeployTunnelEdge(clientSet kubernetes.Interface, manifestsDir,
 	caCertFile, caKeyFile, tunnelCloudToken, tunnelCloudNodeAddr string, tunnelCloudNodePort int32) error {
 
-	caCert, _, err := GetRootCartAndKey(caCertFile, caKeyFile)
+	tunnelEdgeYaml, option, err := getTunnelEdgeResource(clientSet, manifestsDir, caCertFile, caKeyFile, tunnelCloudToken, tunnelCloudNodeAddr, tunnelCloudNodePort)
 	if err != nil {
 		return err
+	}
+
+	err = kubeclient.CreateResourceWithFile(clientSet, tunnelEdgeYaml, option)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DeleteTunnelAddon(client *kubernetes.Clientset, manifestsDir, caCertFile, caKeyFile string, tunnelCloudPublicAddr string, certSANs []string) error {
+	if ok := CheckIfEdgeAppDeletable(client); !ok {
+		klog.Info("Can not Delete Edge Apps, cluster has remaining edge nodes!")
+		return nil
+	}
+
+	// GetTunnelCloudPort
+	tunnelCloudNodePort, err := GetTunnelCloudPort(client)
+	if err != nil {
+		klog.Errorf("Get tunnel-cloud port, error: %v", err)
+		return err
+	}
+
+	// Delete tunnel-edge
+	tunnelCloudToken := util.GetRandToken(32)
+	if err = DeleteTunnelEdge(client, manifestsDir,
+		caCertFile, caKeyFile, tunnelCloudToken, tunnelCloudPublicAddr, tunnelCloudNodePort); err != nil {
+		klog.Errorf("Deploy tunnel-edge, error: %v", err)
+		return err
+	}
+	klog.Infof("Delete %s success!", manifests.APP_TUNNEL_EDGE)
+
+	// Delete tunnel-cloud
+	if err = DeleteTunnelCloud(client, manifestsDir,
+		caCertFile, caKeyFile, tunnelCloudToken, certSANs); err != nil {
+		klog.Errorf("Deploy tunnel-cloud, error: %v", err)
+		return err
+	}
+	klog.Infof("Delete %s success!", manifests.APP_TUNNEL_CLOUD)
+
+	// Delete tunnel-coredns
+	option := map[string]interface{}{
+		"TunnelCoreDNSClusterIP": "",
+	}
+	userManifests := filepath.Join(manifestsDir, manifests.APP_TUNNEL_CORDDNS)
+	TunnelCoredns := ReadYaml(userManifests, manifests.TunnelCorednsYaml)
+	err = kubeclient.DeleteResourceWithFile(client, TunnelCoredns, option)
+	if err != nil {
+		return err
+	}
+	klog.Infof("Delete %s success!", manifests.APP_TUNNEL_CORDDNS)
+
+	return err
+}
+
+func DeleteTunnelCloud(clientSet kubernetes.Interface, manifestsDir, caCertFile, caKeyFile, tunnelCloudToken string, certSANs []string) error {
+	tunnelCloudYaml, option, err := getTunnelCloudResource(clientSet, manifestsDir, caCertFile, caKeyFile, tunnelCloudToken, certSANs)
+	if err != nil {
+		return err
+	}
+	err = kubeclient.DeleteResourceWithFile(clientSet, tunnelCloudYaml, option)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DeleteTunnelEdge(clientSet kubernetes.Interface, manifestsDir,
+	caCertFile, caKeyFile, tunnelCloudToken string, tunnelCloudNodeAddr string, tunnelCloudNodePort int32) error {
+	tunnelEdgeYaml, option, err := getTunnelEdgeResource(clientSet, manifestsDir, caCertFile, caKeyFile, tunnelCloudToken, tunnelCloudNodeAddr, tunnelCloudNodePort)
+	if err != nil {
+		return err
+	}
+
+	err = kubeclient.DeleteResourceWithFile(clientSet, tunnelEdgeYaml, option)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getTunnelCloudResource(clientSet kubernetes.Interface, manifestsDir, caCertFile, caKeyFile, tunnelCloudToken string, certSANs []string) (string, interface{}, error) {
+	nodes, err := clientSet.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return "", nil, err
+	}
+
+	var masterIPs []string
+	for _, node := range nodes.Items {
+		if _, ok := node.Labels[constant.KubernetesDefaultRoleLabel]; ok {
+			for _, address := range node.Status.Addresses {
+				if address.Type == v1.NodeInternalIP || address.Type == v1.NodeExternalIP {
+					masterIPs = append(masterIPs, address.Address)
+				}
+			}
+		}
+	}
+
+	dns := []string{
+		"tunnel.cloud.io",
+		"tunnelcloud.superedge.io",
+	}
+	dns = append(dns, certSANs...)
+	serviceCert, serviceKey, err := GetServiceCert("TunnelCloudService", caCertFile, caKeyFile, dns, masterIPs)
+	if err != nil {
+		return "", nil, err
+	}
+
+	tunnelProxyServerCrt, tunnelProxyServerKey, err := GetServiceCert("TunnelCloudClient", caCertFile, caKeyFile, []string{}, []string{})
+	if err != nil {
+		return "", nil, err
+	}
+
+	option := map[string]interface{}{
+		"TunnelCloudEdgeToken":                tunnelCloudToken,
+		"TunnelPersistentConnectionServerKey": base64.StdEncoding.EncodeToString(serviceKey),
+		"TunnelPersistentConnectionServerCrt": base64.StdEncoding.EncodeToString(serviceCert),
+		"TunnelProxyServerKey":                base64.StdEncoding.EncodeToString(tunnelProxyServerKey),
+		"TunnelProxyServerCrt":                base64.StdEncoding.EncodeToString(tunnelProxyServerCrt),
+	}
+
+	userManifests := filepath.Join(manifestsDir, manifests.APP_TUNNEL_CLOUD)
+	tunnelCloudYaml := ReadYaml(userManifests, manifests.TunnelCloudYaml)
+	return tunnelCloudYaml, option, nil
+}
+
+func getTunnelEdgeResource(clientSet kubernetes.Interface, manifestsDir,
+	caCertFile, caKeyFile, tunnelCloudToken string, tunnelCloudNodeAddr string, tunnelCloudNodePort int32) (string, interface{}, error) {
+
+	caCert, _, err := GetRootCartAndKey(caCertFile, caKeyFile)
+	if err != nil {
+		return "", nil, err
 	}
 
 	caClientCert, caClientKey, err := GetClientCert(
 		"TunnelCloudClient", caCertFile, caKeyFile)
 	if err != nil {
-		return err
+		return "", nil, err
 	}
 
 	masterIps, err := GetMasterIps(clientSet)
 	if err != nil {
-		return err
+		return "", nil, err
 	}
 	if tunnelCloudNodeAddr == "" && len(masterIps) > 0 {
 		tunnelCloudNodeAddr = masterIps[0]
@@ -167,10 +264,6 @@ func DeployTunnelEdge(clientSet kubernetes.Interface, manifestsDir,
 
 	userManifests := filepath.Join(manifestsDir, manifests.APP_TUNNEL_EDGE)
 	tunnelEdgeYaml := ReadYaml(userManifests, manifests.TunnelEdgeYaml)
-	err = kubeclient.CreateResourceWithFile(clientSet, tunnelEdgeYaml, option)
-	if err != nil {
-		return err
-	}
 
-	return nil
+	return tunnelEdgeYaml, option, nil
 }

--- a/pkg/edgeadm/constant/const.go
+++ b/pkg/edgeadm/constant/const.go
@@ -43,7 +43,12 @@ const (
 )
 
 const (
-	CMKubeConfig = "kubeconfig.conf"
+	CMKubeConfig               = "kubeconfig.conf"
+	CMKubeProxy                = "kube-proxy"
+	CMKubeProxyNoEdge          = "kube-proxy-no-edge"
+	KubernetesEndpoint         = "kubernetes"
+	KubernetesEndpointNoEdge   = "kubernetes-no-edge"
+	ConfigMapClusterInfoNoEdge = "cluster-info-no-edge"
 )
 
 const (

--- a/pkg/edgeadm/steps/edge_app.go
+++ b/pkg/edgeadm/steps/edge_app.go
@@ -49,7 +49,7 @@ func NewEdgeAppsPhase(config *cmd.EdgeadmConfig) workflow.Phase {
 		Phases: []workflow.Phase{
 			{
 				Name:           "all",
-				Short:          "Install all the edge-apps addons",
+				Short:          "Install all the edge-apps addons to edge Kubernetes cluster",
 				InheritFlags:   getAddonPhaseFlags("all"),
 				RunAllSiblings: true,
 			},
@@ -78,7 +78,7 @@ func NewEdgeAppsPhase(config *cmd.EdgeadmConfig) workflow.Phase {
 				RunIf: func(data workflow.RunData) (bool, error) {
 					return config.IsEnableEdge, nil
 				},
-				Run: runSerivceGroupAddon,
+				Run: runServiceGroupAddon,
 			},
 			{
 				Name:         "lite-apiserver",
@@ -202,7 +202,7 @@ func runEdgeHealthAddon(c workflow.RunData) error {
 	return err
 }
 
-func runSerivceGroupAddon(c workflow.RunData) error {
+func runServiceGroupAddon(c workflow.RunData) error {
 	_, edgeadmConf, client, err := getInitData(c)
 	if err != nil {
 		return err
@@ -261,6 +261,139 @@ func configLiteAPIServer(c workflow.RunData) error {
 	}
 
 	klog.Infof("Config lite-apiserver configMap success")
+
+	return err
+}
+
+func deleteTunnelAddon(c workflow.RunData) error {
+	cfg, edgeadmConf, client, err := getInitData(c)
+	if err != nil {
+		return err
+	}
+
+	if ok := common.CheckIfEdgeAppDeletable(client); !ok {
+		klog.Info("Can not Delete Edge Apps, cluster has remaining edge nodes!")
+		return nil
+	}
+
+	// GetTunnelCloudPort
+	tunnelCloudNodePort, err := common.GetTunnelCloudPort(client)
+	if err != nil {
+		klog.Errorf("Get tunnel-cloud port, error: %v", err)
+		return err
+	}
+
+	// Delete tunnel-edge
+	certSANs := cfg.APIServer.CertSANs
+	caKeyFile := filepath.Join(cfg.CertificatesDir, kubeadmconstants.CAKeyName)
+	caCertFile := filepath.Join(cfg.CertificatesDir, kubeadmconstants.CACertName)
+	tunnelCloudNodeAddr := cfg.ControlPlaneEndpoint
+	if len(certSANs) > 0 {
+		tunnelCloudNodeAddr = certSANs[0]
+	}
+	if err = common.DeleteTunnelEdge(client, edgeadmConf.ManifestsDir,
+		caCertFile, caKeyFile, edgeadmConf.TunnelCloudToken, tunnelCloudNodeAddr, tunnelCloudNodePort); err != nil {
+		klog.Errorf("Deploy tunnel-edge, error: %v", err)
+		return err
+	}
+	klog.Infof("Delete %s success!", manifests.APP_TUNNEL_EDGE)
+
+	// Delete tunnel-cloud
+	if err = common.DeleteTunnelCloud(client, edgeadmConf.ManifestsDir,
+		caCertFile, caKeyFile, edgeadmConf.TunnelCloudToken, certSANs); err != nil {
+		klog.Errorf("Delete tunnel-cloud, error: %v", err)
+		return err
+	}
+	klog.Infof("Delete %s success!", manifests.APP_TUNNEL_CLOUD)
+
+	// Delete tunnel-coredns
+	option := map[string]interface{}{
+		"TunnelCoreDNSClusterIP": edgeadmConf.TunnelCoreDNSClusterIP,
+	}
+	klog.V(4).Infof("TunnelCoreDNSClusterIP: %s", edgeadmConf.TunnelCoreDNSClusterIP)
+
+	userManifests := filepath.Join(edgeadmConf.ManifestsDir, manifests.APP_TUNNEL_CORDDNS)
+	TunnelCoredns := common.ReadYaml(userManifests, manifests.TunnelCorednsYaml)
+	err = kubeclient.DeleteResourceWithFile(client, TunnelCoredns, option)
+	if err != nil {
+		return err
+	}
+	klog.Infof("Delete %s success!", manifests.APP_TUNNEL_CORDDNS)
+
+	return err
+
+}
+
+func deleteEdgeHealthAddon(c workflow.RunData) error {
+	_, edgeadmConf, client, err := getInitData(c)
+	if err != nil {
+		return err
+	}
+
+	if ok := common.CheckIfEdgeAppDeletable(client); !ok {
+		klog.Info("Can not Delete Edge Apps, cluster has remaining edge nodes!")
+		return nil
+	}
+
+	if err := common.DeleteEdgeHealth(client, edgeadmConf.ManifestsDir); err != nil {
+		klog.Errorf("Deploy edge health, error: %s", err)
+		return err
+	}
+
+	return err
+}
+
+func deleteServiceGroupAddon(c workflow.RunData) error {
+	_, edgeadmConf, client, err := getInitData(c)
+	if err != nil {
+		return err
+	}
+
+	if ok := common.CheckIfEdgeAppDeletable(client); !ok {
+		klog.Info("Can not Delete Edge Apps, cluster has remaining edge nodes!")
+		return nil
+	}
+
+	if err := common.DeleteServiceGroup(client, edgeadmConf.ManifestsDir); err != nil {
+		klog.Errorf("Delete serivce group, error: %s", err)
+		return err
+	}
+
+	klog.Infof("Delete service-group success!")
+
+	return err
+}
+
+func recoverKubeConfig(c workflow.RunData) error {
+	initConfiguration, _, client, err := getInitData(c)
+	if err != nil {
+		return err
+	}
+
+	if ok := common.CheckIfEdgeAppDeletable(client); !ok {
+		klog.Info("Can not Delete Edge Apps, cluster has remaining edge nodes!")
+		return nil
+	}
+
+	if err := common.RecoverKubeProxyKubeconfig(client); err != nil {
+		klog.Errorf("Recover kube-proxy config, error: %s", err)
+		return err
+	}
+
+	if err := common.RecoverKubernetesEndpoint(client); err != nil {
+		klog.Errorf("Recover kubernetes endpoint, error: %s", err)
+		return err
+	}
+
+	if len(initConfiguration.APIServer.CertSANs) > 0 {
+		certSANs := initConfiguration.APIServer.CertSANs
+		if err := common.RecoverClusterInfoKubeconfig(client, certSANs); err != nil {
+			klog.Errorf("Recover cluster-info config, error: %s", err)
+			return err
+		}
+	}
+
+	klog.Infof("Recover Kubernetes cluster config support marginal autonomy success")
 
 	return err
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
enhancement

**What this PR does**:
Add add-on apps deletion feature for edge clusters that use `edgeadm addon edge-apps ` to install edge apps on a Kubernetes cluster.

Users can delete edge apps:
```
./edgeadm detach edge-apps
```
and reinstall them:
```
./edgeadm addon edge-apps
```
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
@attlee-wang 
