### PR TITLE
lite-apiserver: add modify-request-accept param

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1160,6 +1160,7 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/api v0.20.5 h1:zsMTffV0Le2EiI0aKvlTHEnXGxk1HiqGRhJcCPiI7JI=
 k8s.io/api v0.20.5/go.mod h1:FQjAceXnVaWDeov2YUWhOb6Yt+5UjErkp6UO3nczO1Y=
+k8s.io/apiextensions-apiserver v0.20.5 h1:A256l0jtiEqjajKsWAtsXlLoSj+ufSOcx2PeG8/DQHA=
 k8s.io/apiextensions-apiserver v0.20.5/go.mod h1:1HoTwgjWNizJBIgg0Y9P4RdLtaQquilJ5ArGHv9ZpFk=
 k8s.io/apimachinery v0.20.5 h1:wO/FxMVRn223rAKxnBbwCyuN96bS9MFTIvP0e/V7cps=
 k8s.io/apimachinery v0.20.5/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
@@ -1223,6 +1224,7 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
+sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15 h1:4uqm9Mv+w2MmBYD+F4qf/v6tDFUdPOk29C095RbU5mY=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/controller-runtime v0.8.3/go.mod h1:U/l+DUopBc1ecfRZ5aviA9JDmGFQKvLf5YkZNx2e0sU=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=

--- a/pkg/lite-apiserver/config/config.go
+++ b/pkg/lite-apiserver/config/config.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package config
 
-import "time"
-
 type LiteServerConfig struct {
 	// lite-server default ca path for kubernetes apiserver
 	// CAFile defines the certificate authority
@@ -45,7 +43,7 @@ type LiteServerConfig struct {
 
 	TLSConfig []TLSKeyPair
 
-	SyncDuration time.Duration
+	ModifyRequestAccept bool
 
 	CacheType       string
 	FileCachePath   string

--- a/pkg/lite-apiserver/options/server_options.go
+++ b/pkg/lite-apiserver/options/server_options.go
@@ -24,18 +24,19 @@ import (
 )
 
 type RunServerOptions struct {
-	KubeApiserverUrl  string
-	KubeApiserverPort int
-	Port              int
-	BackendTimeout    int
-	CAFile            string
-	CertFile          string
-	KeyFile           string
-	ApiserverCAFile   string
-	CacheType         string
-	FileCachePath     string
-	BadgerCachePath   string
-	BoltCacheFile     string
+	KubeApiserverUrl    string
+	KubeApiserverPort   int
+	Port                int
+	BackendTimeout      int
+	CAFile              string
+	CertFile            string
+	KeyFile             string
+	ApiserverCAFile     string
+	ModifyRequestAccept bool
+	CacheType           string
+	FileCachePath       string
+	BadgerCachePath     string
+	BoltCacheFile       string
 }
 
 func NewRunServerOptions() *RunServerOptions {
@@ -51,6 +52,8 @@ func (s *RunServerOptions) ApplyTo(c *config.LiteServerConfig) error {
 	c.KubeApiserverPort = s.KubeApiserverPort
 	c.Port = s.Port
 	c.BackendTimeout = s.BackendTimeout
+
+	c.ModifyRequestAccept = s.ModifyRequestAccept
 
 	c.CacheType = s.CacheType
 	c.FileCachePath = s.FileCachePath
@@ -105,8 +108,10 @@ func (s *RunServerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.KubeApiserverUrl, "kube-apiserver-url", "", "the host of kube-apiserver")
 	fs.IntVar(&s.KubeApiserverPort, "kube-apiserver-port", 443, "the port of kube-apiserver")
 
-	fs.IntVar(&s.Port, "port", 51003, "the port on the local server to listen on.")
+	fs.IntVar(&s.Port, "port", 51003, "the port on the local server to listen on")
 	fs.IntVar(&s.BackendTimeout, "timeout", 3, "timeout for proxy to backend")
+
+	fs.BoolVar(&s.ModifyRequestAccept, "modify-request-accept", true, "whether modify client request Accept to default(application/json), default is true")
 
 	fs.StringVar(&s.CacheType, "cache-type", "file", "the type for cache storage. file(default), memory(only for test), badger, bolt")
 	fs.StringVar(&s.FileCachePath, "file-cache-path", "/data/lite-apiserver/cache", "the path for file storage")

--- a/pkg/lite-apiserver/proxy/handler.go
+++ b/pkg/lite-apiserver/proxy/handler.go
@@ -70,7 +70,7 @@ func NewEdgeServerHandler(config *config.LiteServerConfig, transportManager *tra
 	// start to handle new proxy
 	h.start()
 
-	return h.buildHandlerChain(h), nil
+	return h.buildHandlerChain(config, h), nil
 }
 
 func (h *EdgeServerHandler) initProxies() {
@@ -107,8 +107,10 @@ func (h *EdgeServerHandler) start() {
 	}()
 }
 
-func (h *EdgeServerHandler) buildHandlerChain(handler http.Handler) http.Handler {
-	handler = WithRequestAccept(handler)
+func (h *EdgeServerHandler) buildHandlerChain(config *config.LiteServerConfig, handler http.Handler) http.Handler {
+	if config.ModifyRequestAccept {
+		handler = WithRequestAccept(handler)
+	}
 
 	cfg := &server.Config{
 		LegacyAPIGroupPrefixes: sets.NewString(server.DefaultLegacyAPIPrefix),

--- a/pkg/lite-apiserver/proxy/proxy.go
+++ b/pkg/lite-apiserver/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/superedge/superedge/pkg/lite-apiserver/cache"
+	"github.com/superedge/superedge/pkg/lite-apiserver/constant"
 	"github.com/superedge/superedge/pkg/lite-apiserver/transport"
 )
 
@@ -91,6 +93,24 @@ func (p *EdgeReverseProxy) modifyResponse(resp *http.Response) error {
 	if resp.StatusCode != http.StatusOK {
 		klog.V(4).Infof("resp status is %d, skip cache response", resp.StatusCode)
 		return nil
+	}
+
+	// validate watch Content-Type
+	info, ok := apirequest.RequestInfoFrom(resp.Request.Context())
+	if !ok {
+		return nil
+	}
+	if info.Verb == constant.VerbWatch {
+		contentType := resp.Header.Get(constant.ContentType)
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			klog.Warningf("Content-Type %s is not recognized: %v", contentType, err)
+			return nil
+		}
+		klog.V(8).Infof("mediaType is %s", mediaType)
+		if mediaType != "application/json" && mediaType != "application/yaml" {
+			return nil
+		}
 	}
 
 	// cache response data


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes #90 . Add --modify-request-accept param (default is true) for lite-apiserver. 
We can set --modify-request-accept=false for old version of k8s, to avoid https://github.com/kubernetes/kubernetes/pull/84692 .


