### PR TITLE
edgeadm: Add install add-on edge apps in TKE cluster feature.

### DIFF
--- a/pkg/edgeadm/cmd/addon/addon.go
+++ b/pkg/edgeadm/cmd/addon/addon.go
@@ -36,6 +36,7 @@ type addonAction struct {
 	caCertFile       string
 	masterPublicAddr string
 	certSANs         []string
+	kubeConfig       string
 }
 
 func NewAddonCMD() *cobra.Command {
@@ -72,6 +73,6 @@ func (a *addonAction) complete() error {
 	if a.clientSet == nil {
 		return fmt.Errorf("Please set kubeconfig value!\n")
 	}
-
+	a.kubeConfig = configPath
 	return nil
 }

--- a/pkg/edgeadm/cmd/addon/edgeapps.go
+++ b/pkg/edgeadm/cmd/addon/edgeapps.go
@@ -35,7 +35,7 @@ func NewInstallEdgeAppsCMD() *cobra.Command {
 
 	cmd.Flags().StringVar(&action.caKeyFile, "ca.key", constant.KubeadmKeyPath,
 		"The root certificate key file for cluster.")
-	cmd.Flags().StringVar(&action.masterPublicAddr, "masterPublicAddr", "",
+	cmd.Flags().StringVar(&action.masterPublicAddr, "master-public-addr", "",
 		"The public IP for control plane")
 	cmd.Flags().StringArrayVar(&action.certSANs, "certSANs", []string{""},
 		"The cert SAN")
@@ -68,7 +68,7 @@ func NewDetachEdgeAppsCMD() *cobra.Command {
 
 	cmd.Flags().StringVar(&action.caKeyFile, "ca.key", constant.KubeadmKeyPath,
 		"The root certificate key file for cluster. (default \"/etc/kubernetes/pki/ca.key\")")
-	cmd.Flags().StringVar(&action.masterPublicAddr, "masterPublicAddr", "",
+	cmd.Flags().StringVar(&action.masterPublicAddr, "master-public-addr", "",
 		"The public IP for control plane")
 	cmd.Flags().StringArrayVar(&action.certSANs, "certSANs", []string{""},
 		"The cert SAN")
@@ -78,7 +78,7 @@ func NewDetachEdgeAppsCMD() *cobra.Command {
 
 func (a *addonAction) runAddon() error {
 	klog.Info("Start install addon apps to your original cluster")
-	return common.DeployEdgeAPPS(a.clientSet, a.manifestDir, a.caCertFile, a.caKeyFile, a.masterPublicAddr, a.certSANs)
+	return common.DeployEdgeAPPS(a.clientSet, a.manifestDir, a.caCertFile, a.caKeyFile, a.masterPublicAddr, a.certSANs, a.kubeConfig)
 }
 
 func (a *addonAction) runDetach() error {

--- a/pkg/edgeadm/common/deploy_edge_preflight.go
+++ b/pkg/edgeadm/common/deploy_edge_preflight.go
@@ -1,0 +1,474 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	clusterinfophase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/clusterinfo"
+	nodebootstraptokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
+	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+
+	"github.com/superedge/superedge/pkg/edgeadm/constant"
+	"github.com/superedge/superedge/pkg/edgeadm/constant/manifests"
+	"github.com/superedge/superedge/pkg/util/kubeclient"
+)
+
+const (
+	NodesKubeadmConfigClusterRoleName = "kubeadm:nodes-kubeadm-config"
+	GetNodesClusterRoleName           = "kubeadm:get-nodes"
+	NodeBootstrapperClusterRoleName   = "system:node-bootstrapper"
+	KubeletBootstrapClusterRoleName   = "kubeadm:kubelet-bootstrap"
+)
+
+// DeployEdgePreflight is a preflight step for the addon.
+func DeployEdgePreflight(clientSet kubernetes.Interface, manifestsDir string, masterPublicAddr string, configPath string) error {
+	if err := ensureKubePublicNamespace(clientSet); err != nil {
+		return err
+	}
+
+	if err := ensureBootstrapTokenRBAC(clientSet, masterPublicAddr, manifestsDir, configPath); err != nil {
+		return err
+	}
+	clusterConfiguration, err := ensureKubeadmConfigConfigMap(clientSet, configPath)
+	if err != nil {
+		return err
+	}
+
+	if err := ensureKubeletConfigMap(clientSet, clusterConfiguration); err != nil {
+		return err
+	}
+
+	if err := ensureKubeadmRBAC(clientSet); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ensureKubePublicNamespace ensure the namespace kube-public exits.
+func ensureKubePublicNamespace(client kubernetes.Interface) error {
+	if err := kubeclient.CreateOrUpdateNamespace(client, &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constant.NamespaceKubePublic,
+		},
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureBootstrapTokenRBAC ensure the bootstrap token RBAC rules exist.
+func ensureBootstrapTokenRBAC(clientSet kubernetes.Interface, masterPublicAddr string, manifestsDir string, configPath string) error {
+
+	// Create RBAC rules that makes the bootstrap tokens able to get nodes
+	if err := nodebootstraptokenphase.AllowBoostrapTokensToGetNodes(clientSet); err != nil {
+		return errors.Wrap(err, "error allowing bootstrap tokens to get Nodes")
+	}
+	// Create RBAC rules that makes the bootstrap tokens able to post CSRs
+	if err := nodebootstraptokenphase.AllowBootstrapTokensToPostCSRs(clientSet); err != nil {
+		return errors.Wrap(err, "error allowing bootstrap tokens to post CSRs")
+	}
+	// Create RBAC rules that makes the bootstrap tokens able to get their CSRs approved automatically
+	if err := nodebootstraptokenphase.AutoApproveNodeBootstrapTokens(clientSet); err != nil {
+		return errors.Wrap(err, "error auto-approving node bootstrap tokens")
+	}
+
+	// Create/update RBAC rules that makes the nodes to rotate certificates and get their CSRs approved automatically
+	if err := nodebootstraptokenphase.AutoApproveNodeCertificateRotation(clientSet); err != nil {
+		return err
+	}
+
+	// Create the cluster-info ConfigMap with the associated RBAC rules
+	if err := createBootstrapConfigMapIfNotExists(clientSet, masterPublicAddr, manifestsDir, configPath); err != nil {
+		return errors.Wrap(err, "error creating bootstrap ConfigMap")
+	}
+
+	if err := clusterinfophase.CreateClusterInfoRBACRules(clientSet); err != nil {
+		return errors.Wrap(err, "error creating clusterinfo RBAC rules")
+	}
+	return nil
+}
+
+// createBootstrapConfigMapIfNotExists ensure the bootstrap configmap exists.
+func createBootstrapConfigMapIfNotExists(clientSet kubernetes.Interface, masterPublicAddr string, manifestsDir string, configPath string) error {
+	clusterInfoKubeConfig := filepath.Join(manifestsDir, manifests.ClusterInfoKubeConfig)
+	cluster, err := kubeclient.GetClusterInfo(configPath)
+	if err != nil {
+		return err
+	}
+	server := cluster.Server
+	if masterPublicAddr != "" {
+		server = fmt.Sprintf("https://%s", masterPublicAddr)
+	}
+	yamlKubeConfig, err := kubeclient.ParseString(
+		ReadYaml(clusterInfoKubeConfig, manifests.ClusterInfoKubeConfigYaml),
+		map[string]interface{}{
+			"Server": server,
+			"CAData": base64.StdEncoding.EncodeToString(cluster.CertificateAuthorityData),
+		})
+	if err != nil {
+		return err
+	}
+
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-info",
+			Namespace: constant.NamespaceKubePublic,
+		},
+		Data: map[string]string{
+			"kubeconfig": string(yamlKubeConfig),
+		},
+	}
+
+	return apiclient.CreateOrRetainConfigMap(clientSet, configMap, "cluster-info")
+}
+
+// ensureKubeadmRBAC ensure the RBAC rules for the kubeadm.
+func ensureKubeadmRBAC(clientSet kubernetes.Interface) error {
+	// kubeadm:nodes-kubeadm-config
+	role := rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NodesKubeadmConfigClusterRoleName,
+			Namespace: constant.NamespaceKubeSystem,
+		},
+		Rules: nil,
+	}
+
+	role.Rules = append(role.Rules, rbacv1.PolicyRule{
+		APIGroups:     []string{"*"},
+		Resources:     []string{"configmaps"},
+		ResourceNames: []string{kubeadmconstants.KubeadmConfigConfigMap},
+		Verbs:         []string{"get", "list", "watch"},
+	})
+
+	roleBinding := rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NodesKubeadmConfigClusterRoleName,
+			Namespace: constant.NamespaceKubeSystem,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name:     NodesKubeadmConfigClusterRoleName,
+			Kind:     "Role",
+			APIGroup: rbacv1.GroupName,
+		},
+		Subjects: nil,
+	}
+
+	roleBinding.Subjects = append(roleBinding.Subjects, rbacv1.Subject{
+		APIGroup: rbacv1.GroupName,
+		Kind:     rbacv1.GroupKind,
+		Name:     kubeadmconstants.NodeBootstrapTokenAuthGroup,
+	}, rbacv1.Subject{
+		APIGroup: rbacv1.GroupName,
+		Kind:     rbacv1.GroupKind,
+		Name:     kubeadmconstants.NodesGroup,
+	})
+
+	//kubeadm:get-nodes
+	getNodeClusterRole := rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: GetNodesClusterRoleName,
+		},
+		Rules: nil,
+	}
+
+	getNodeClusterRole.Rules = append(getNodeClusterRole.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{""},
+		Resources: []string{"nodes"},
+		Verbs:     []string{"get"},
+	})
+
+	getNodeClusterRoleBinding := rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GetNodesClusterRoleName,
+			Namespace: constant.NamespaceKubeSystem,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name:     GetNodesClusterRoleName,
+			Kind:     "ClusterRole",
+			APIGroup: rbacv1.GroupName,
+		},
+		Subjects: nil,
+	}
+
+	getNodeClusterRoleBinding.Subjects = append(getNodeClusterRoleBinding.Subjects, rbacv1.Subject{
+		APIGroup: rbacv1.GroupName,
+		Kind:     rbacv1.GroupKind,
+		Name:     kubeadmconstants.NodeBootstrapTokenAuthGroup,
+	})
+
+	//kubeadm:kubelet-bootstrap
+	kubeletBootstrapClusterRole := rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: NodeBootstrapperClusterRoleName,
+		},
+		Rules: nil,
+	}
+
+	kubeletBootstrapClusterRole.Rules = append(kubeletBootstrapClusterRole.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{"certificates.k8s.io"},
+		Resources: []string{"certificatesigningrequests"},
+		Verbs:     []string{"get", "list", "watch", "create"},
+	})
+
+	kubeletBootstrapClusterRoleBinding := rbacv1.ClusterRoleBinding{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubeletBootstrapClusterRoleName,
+			Namespace: constant.NamespaceKubeSystem,
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name:     NodeBootstrapperClusterRoleName,
+			Kind:     "ClusterRole",
+			APIGroup: rbacv1.GroupName,
+		},
+		Subjects: nil,
+	}
+
+	kubeletBootstrapClusterRoleBinding.Subjects = append(kubeletBootstrapClusterRoleBinding.Subjects, rbacv1.Subject{
+		APIGroup: rbacv1.GroupName,
+		Kind:     rbacv1.GroupKind,
+		Name:     kubeadmconstants.NodeBootstrapTokenAuthGroup,
+	})
+
+	if err := apiclient.CreateOrUpdateRole(clientSet, &role); err != nil {
+		return err
+	}
+
+	if err := apiclient.CreateOrUpdateRoleBinding(clientSet, &roleBinding); err != nil {
+		return err
+	}
+
+	if err := apiclient.CreateOrUpdateClusterRole(clientSet, &getNodeClusterRole); err != nil {
+		return err
+	}
+
+	if err := apiclient.CreateOrUpdateClusterRoleBinding(clientSet, &getNodeClusterRoleBinding); err != nil {
+		return err
+	}
+
+	if err := apiclient.CreateOrUpdateClusterRole(clientSet, &kubeletBootstrapClusterRole); err != nil {
+		return err
+	}
+
+	return apiclient.CreateOrUpdateClusterRoleBinding(clientSet, &kubeletBootstrapClusterRoleBinding)
+}
+
+// ensureKubeadmConfigConfigMap ensure a ConfigMap with the generic kubeadm configuration.
+func ensureKubeadmConfigConfigMap(clientSet kubernetes.Interface, configPath string) (*kubeadmapi.ClusterConfiguration, error) {
+	hostname, err := kubeadmutil.GetHostname("")
+	cluster, err := kubeclient.GetClusterInfo(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterConfigurationToUpload := &kubeadmapi.ClusterConfiguration{
+		APIServer: kubeadmapi.APIServer{
+			TimeoutForControlPlane: &metav1.Duration{
+				Duration: kubeadmconstants.DefaultControlPlaneTimeout,
+			},
+		},
+		DNS: kubeadmapi.DNS{
+			Type: kubeadmapi.CoreDNS,
+		},
+		CertificatesDir: v1beta2.DefaultCertificatesDir,
+		ClusterName:     v1beta2.DefaultClusterName,
+		Etcd: kubeadmapi.Etcd{
+			Local: &kubeadmapi.LocalEtcd{
+				DataDir: v1beta2.DefaultEtcdDataDir,
+			},
+		},
+		ImageRepository:   constant.ImageRepository,
+		KubernetesVersion: kubeadmconstants.CurrentKubernetesVersion.String(),
+		Networking: kubeadmapi.Networking{
+			ServiceSubnet: v1beta2.DefaultServicesSubnet,
+			DNSDomain:     v1beta2.DefaultServiceDNSDomain,
+		},
+	}
+	clusterConfigurationToUpload.ComponentConfigs = kubeadmapi.ComponentConfigMap{}
+
+	// Marshal the ClusterConfiguration into YAML
+	clusterConfigurationYaml, err := configutil.MarshalKubeadmConfigObject(clusterConfigurationToUpload)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare the ClusterStatus for upload
+	clusterUrl, err := url.Parse(cluster.Server)
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing cluster server")
+	}
+	apiEndpoint, err := kubeadmapi.APIEndpointFromString(clusterUrl.Host)
+	if err != nil {
+		return nil, err
+	}
+	clusterStatus := &kubeadmapi.ClusterStatus{
+		APIEndpoints: map[string]kubeadmapi.APIEndpoint{
+			hostname: apiEndpoint,
+		},
+	}
+	// Marshal the ClusterStatus into YAML
+	clusterStatusYaml, err := configutil.MarshalKubeadmConfigObject(clusterStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kubeadmconstants.KubeadmConfigConfigMap,
+			Namespace: constant.NamespaceKubeSystem,
+		},
+		Data: map[string]string{
+			kubeadmconstants.ClusterConfigurationConfigMapKey: string(clusterConfigurationYaml),
+			kubeadmconstants.ClusterStatusConfigMapKey:        string(clusterStatusYaml),
+		},
+	}
+
+	apiclient.CreateOrRetainConfigMap(clientSet, configMap, kubeadmconstants.KubeadmConfigConfigMap)
+	return clusterConfigurationToUpload, nil
+}
+
+// ensureKubeletConfigMap ensure a ConfigMap with the generic kubelet configuration.
+func ensureKubeletConfigMap(clientSet kubernetes.Interface, clusterConfiguration *kubeadmapi.ClusterConfiguration) error {
+	clusterCfg := &kubeadmapiv1beta2.ClusterConfiguration{
+		KubernetesVersion: kubeadmconstants.CurrentKubernetesVersion.String(),
+	}
+	internalcfg, err := configutil.DefaultedInitConfiguration(&kubeadmapiv1beta2.InitConfiguration{}, clusterCfg)
+	if err != nil {
+		errors.Wrapf(err, "unexpected failure by DefaultedInitConfiguration: %v")
+	}
+	klog.V(1).Infoln("[upload-config] Uploading the kubelet component config to a ConfigMap")
+	if err := createConfigMap(&internalcfg.ClusterConfiguration, clientSet); err != nil {
+		return errors.Wrap(err, "error creating kubelet configuration ConfigMap")
+	}
+	return nil
+}
+
+// createConfigMap creates a ConfigMap with the generic kubelet configuration.
+func createConfigMap(cfg *kubeadmapi.ClusterConfiguration, client kubernetes.Interface) error {
+
+	k8sVersion, err := version.ParseSemantic(cfg.KubernetesVersion)
+	if err != nil {
+		return err
+	}
+
+	configMapName := kubeadmconstants.GetKubeletConfigMapName(k8sVersion)
+	klog.V(1).Infof("[kubelet] Creating a ConfigMap %q in namespace %s with the configuration for the kubelets in the cluster\n", configMapName, constant.NamespaceKubeSystem)
+
+	kubeletCfg, ok := cfg.ComponentConfigs[componentconfigs.KubeletGroup]
+	if !ok {
+		return errors.New("no kubelet component config found in the active component config set")
+	}
+
+	kubeletBytes, err := kubeletCfg.Marshal()
+	if err != nil {
+		return err
+	}
+
+	configMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: constant.NamespaceKubeSystem,
+		},
+		Data: map[string]string{
+			kubeadmconstants.KubeletBaseConfigurationConfigMapKey: string(kubeletBytes),
+		},
+	}
+
+	if !kubeletCfg.IsUserSupplied() {
+		componentconfigs.SignConfigMap(configMap)
+	}
+
+	if err := apiclient.CreateOrRetainConfigMap(client, configMap, configMapName); err != nil {
+		return err
+	}
+
+	if err := createConfigMapRBACRules(client, k8sVersion); err != nil {
+		return errors.Wrap(err, "error creating kubelet configuration configmap RBAC rules")
+	}
+	return nil
+}
+
+// createConfigMapRBACRules creates the RBAC rules for exposing the base kubelet ConfigMap in the kube-system namespace to unauthenticated users
+func createConfigMapRBACRules(client kubernetes.Interface, k8sVersion *version.Version) error {
+	if err := apiclient.CreateOrUpdateRole(client, &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapRBACName(k8sVersion),
+			Namespace: metav1.NamespaceSystem,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				Verbs:         []string{"get"},
+				APIGroups:     []string{""},
+				Resources:     []string{"configmaps"},
+				ResourceNames: []string{kubeadmconstants.GetKubeletConfigMapName(k8sVersion)},
+			},
+		},
+	}); err != nil {
+		return err
+	}
+
+	return apiclient.CreateOrUpdateRoleBinding(client, &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapRBACName(k8sVersion),
+			Namespace: metav1.NamespaceSystem,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     configMapRBACName(k8sVersion),
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: rbacv1.GroupKind,
+				Name: kubeadmconstants.NodesGroup,
+			},
+			{
+				Kind: rbacv1.GroupKind,
+				Name: kubeadmconstants.NodeBootstrapTokenAuthGroup,
+			},
+		},
+	})
+}
+
+// configMapRBACName returns the name for the Role/RoleBinding for the kubelet config configmap for the right branch of k8s
+func configMapRBACName(k8sVersion *version.Version) string {
+	return fmt.Sprintf("%s%d.%d", kubeadmconstants.KubeletBaseConfigMapRolePrefix, k8sVersion.Major(), k8sVersion.Minor())
+}

--- a/pkg/edgeadm/common/deploy_service_group.go
+++ b/pkg/edgeadm/common/deploy_service_group.go
@@ -38,22 +38,17 @@ func DeployServiceGroup(clientSet kubernetes.Interface, manifestsDir string) err
 	if err != nil {
 		return err
 	}
-
-	userGridWrapper := filepath.Join(manifestsDir, manifests.APP_APPLICATION_GRID_WRAPPER)
-	gridWrapper = ReadYaml(userGridWrapper, manifests.ApplicationGridWrapperYaml)
 	if err := kubeclient.CreateResourceWithFile(clientSet, gridWrapper, option); err != nil {
 		return err
 	}
 	klog.V(4).Infof("Deploy %s success!", manifests.APP_APPLICATION_GRID_WRAPPER)
 
-	userGridController := filepath.Join(manifestsDir, manifests.APP_APPLICATION_GRID_CONTROLLER)
-	gridController = ReadYaml(userGridController, manifests.ApplicationGridControllerYaml)
 	if err := kubeclient.CreateResourceWithFile(clientSet, gridController, option); err != nil {
 		klog.Errorf("Deploy %s error: %s", manifests.APP_APPLICATION_GRID_CONTROLLER, err)
 		return err
 	}
 
-	klog.V(4).Infof("Create %s success!", manifests.APP_APPLICATION_GRID_CONTROLLER)
+	klog.V(4).Infof("Deploy %s success!", manifests.APP_APPLICATION_GRID_CONTROLLER)
 
 	return nil
 }
@@ -69,8 +64,7 @@ func DeleteServiceGroup(clientSet kubernetes.Interface, manifestsDir string) err
 	}
 	klog.V(4).Infof("Delete %s success!", manifests.APP_APPLICATION_GRID_WRAPPER)
 
-	if err := DeleteByYamlFile(clientSet, gridController); err != nil {
-		klog.Errorf("Delete %s error: %s", manifests.APP_APPLICATION_GRID_CONTROLLER, err)
+	if err := kubeclient.DeleteResourceWithFile(clientSet, gridController, option); err != nil {
 		return err
 	}
 

--- a/pkg/edgeadm/common/deploy_tunnel.go
+++ b/pkg/edgeadm/common/deploy_tunnel.go
@@ -115,11 +115,6 @@ func DeployTunnelEdge(clientSet kubernetes.Interface, manifestsDir,
 }
 
 func DeleteTunnelAddon(client *kubernetes.Clientset, manifestsDir, caCertFile, caKeyFile string, tunnelCloudPublicAddr string, certSANs []string) error {
-	if ok := CheckIfEdgeAppDeletable(client); !ok {
-		klog.Info("Can not Delete Edge Apps, cluster has remaining edge nodes!")
-		return nil
-	}
-
 	// GetTunnelCloudPort
 	tunnelCloudNodePort, err := GetTunnelCloudPort(client)
 	if err != nil {

--- a/pkg/edgeadm/common/update_config.go
+++ b/pkg/edgeadm/common/update_config.go
@@ -213,12 +213,12 @@ func PatchKubeProxy(clientSet kubernetes.Interface) error {
 
 func RecoverKubeConfig(client *kubernetes.Clientset) error {
 	if err := RecoverKubeProxyKubeconfig(client); err != nil {
-		klog.Errorf("Delete serivce group, error: %s", err)
+		klog.Errorf("Recover kube-proxy kubeconfig, error: %s", err)
 		return err
 	}
 
 	if err := RecoverKubernetesEndpoint(client); err != nil {
-		klog.Errorf("Delete serivce group, error: %s", err)
+		klog.Errorf("Recover kube-proxy endpoint, error: %s", err)
 		return err
 	}
 

--- a/pkg/edgeadm/constant/const.go
+++ b/pkg/edgeadm/constant/const.go
@@ -35,6 +35,7 @@ const (
 	NamespaceDefault    = "default"
 	NamespaceEdgeSystem = "edge-system"
 	NamespaceKubeSystem = "kube-system"
+	NamespaceKubePublic = "kube-public"
 )
 
 const (
@@ -104,3 +105,5 @@ const (
 const ApplicationGridWrapperServiceAddr = "http://127.0.0.1:51006"
 
 const LiteAPIServerTLSCfg = `[{"key":"/var/lib/kubelet/pki/kubelet-client-current.pem","cert":"/var/lib/kubelet/pki/kubelet-client-current.pem"}]`
+
+const ImageRepository = "superedge.tencentcloudcr.com/superedge"

--- a/pkg/edgeadm/constant/manifests/edge-preflight.go
+++ b/pkg/edgeadm/constant/manifests/edge-preflight.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifests
+
+const ClusterInfoKubeConfig = "cluster-info-role.yaml"
+
+const ClusterInfoKubeConfigYaml = `
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: {{.CAData}}
+    server: {{.Server}}
+  name: ""
+contexts: null
+current-context: ""
+kind: Config
+preferences: {}
+users: null
+`

--- a/pkg/util/kubeadm/token.go
+++ b/pkg/util/kubeadm/token.go
@@ -134,9 +134,9 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 
 	options.AddConfigFlag(createCmd.Flags(), &cfgPath)
 	createCmd.Flags().BoolVar(&printJoinCommand,
-		"print-join-command", false, "Instead of printing only the token, print the full 'kubeadm join' flag needed to join the cluster using the token.")
+		"print-join-command", false, "Instead of printing only the token, print the full 'edgeadm join' flag needed to join the cluster using the token.")
 	createCmd.Flags().StringVar(&certificateKey,
-		options.CertificateKey, "", "When used together with '--print-join-command', print the full 'kubeadm join' flag needed to join the cluster as a control-plane. To create a new certificate key you must use 'kubeadm init phase upload-certs --upload-certs'.")
+		options.CertificateKey, "", "When used together with '--print-join-command', print the full 'edgeadm join' flag needed to join the cluster as a control-plane. To create a new certificate key you must use 'kubeadm init phase upload-certs --upload-certs'.")
 	bto.AddTTLFlagWithName(createCmd.Flags(), "ttl")
 	bto.AddUsagesFlag(createCmd.Flags())
 	bto.AddGroupsFlag(createCmd.Flags())
@@ -250,7 +250,7 @@ func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, i
 		return err
 	}
 
-	// if --print-join-command was specified, print a machine-readable full `kubeadm join` command
+	// if --print-join-command was specified, print a machine-readable full `edgeadm join` command
 	// otherwise, just print the token
 	if printJoinCommand {
 		skipTokenPrint := false
@@ -262,6 +262,7 @@ func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, i
 			}
 			joinCommand = strings.ReplaceAll(joinCommand, "\\\n", "")
 			joinCommand = strings.ReplaceAll(joinCommand, "\t", "")
+			joinCommand = strings.ReplaceAll(joinCommand, "kubeadm", "edgeadm")
 			fmt.Fprintln(out, joinCommand)
 		} else {
 			joinCommand, err := cmdutil.GetJoinWorkerCommand(kubeConfigFile, internalcfg.BootstrapTokens[0].Token.String(), skipTokenPrint)
@@ -270,6 +271,7 @@ func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, i
 			}
 			joinCommand = strings.ReplaceAll(joinCommand, "\\\n", "")
 			joinCommand = strings.ReplaceAll(joinCommand, "\t", "")
+			joinCommand = strings.ReplaceAll(joinCommand, "kubeadm", "edgeadm")
 			fmt.Fprintln(out, joinCommand)
 		}
 	} else {

--- a/pkg/util/kubeclient/client.go
+++ b/pkg/util/kubeclient/client.go
@@ -20,18 +20,21 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/homedir"
 	"k8s.io/klog/v2"
+	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 
 	"github.com/superedge/superedge/pkg/util"
 )
@@ -191,4 +194,48 @@ func CheckNodeLabel(kubeClient *kubernetes.Clientset, nodeName string, labels ma
 		}
 	}
 	return true, nil
+}
+
+func GetClusterInfo(kubeconfigFile string) (*api.Cluster, error) {
+	if !util.IsFileExist(kubeconfigFile) {
+		kubeconfigFile = ""
+	}
+
+	if kubeconfigFile == "" {
+		kubeconfigFile = os.Getenv("KUBECONFIG")
+	}
+
+	if kubeconfigFile == "" {
+		if home := homedir.HomeDir(); home != "" {
+			kubeconfigFile = filepath.Join(home, ".kube", "config")
+		}
+	}
+
+	if !util.IsFileExist(kubeconfigFile) {
+		kubeconfigFile = ""
+	}
+
+	if kubeconfigFile == "" {
+		kubeconfigFile = CustomConfig()
+	}
+
+	if kubeconfigFile == "" {
+		return nil, fmt.Errorf("kubeconfig nil, Please appoint --kubeconfig, KUBECONFIG or ~/.kube/config")
+	}
+
+	os.Setenv("KUBECONF", kubeconfigFile)
+	os.Setenv("KUBECONFIG", kubeconfigFile)
+
+	// load the kubeconfig file to get the CA certificate and endpoint
+	config, err := clientcmd.LoadFromFile(kubeconfigFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to load kubeconfig")
+	}
+
+	// load the default cluster config
+	clusterConfig := kubeconfigutil.GetClusterFromKubeConfig(config)
+	if clusterConfig == nil {
+		return nil, errors.New("failed to get default cluster config")
+	}
+	return clusterConfig, nil
 }


### PR DESCRIPTION
Signed-off-by: lianghao208 <302824716@qq.com>

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
enhancement
**What this PR does**:
Add add-on edge apps in TKE cluster( or any Kubernetes clusters weren't installed by kubeadm) feature,

Users can add-on edge apps and join edge node into clusters in following steps:
1. Install add-on edge apps (master node)
```
./edgeadm addon edge-apps  --ca.cert /etc/kubernetes/ca.crt --ca.key /etc/kubernetes/ca.key --master-public-addr <apiserver public address/ domain>:<port>
```
2. Print join command (master node)
```
./edgeadm token create --print-join-command
```
3.  Download installation package (worker node)
```
arch=amd64 version=v0.3.0 && rm -rf edgeadm-linux-*&& wget https://superedge-1253687700.cos.ap-guangzhou.myqcloud.com/$version/$arch/edgeadm-linux-$arch-$version.tgz && tar -xzvf edgeadm-linux-*&&cd edgeadm-linux-$arch-$version
```
4. Join the edge worker node into the cluster (worker node)
```
./edgeadm join <apiserver public address/ internal address/ domain>:<port> --token xxxx --discovery-token-ca-cert-hash sha256:xxxxxxxxxx --install-pkg-path <path of installation package> --enable-edge=true
```


**Special notes for your reviewer**:
@attlee-wang 