### PR TITLE
edgeadm:  get master ip from cluster-info when print join command

### DIFF
--- a/pkg/edgeadm/cmd/addon/edgeapps.go
+++ b/pkg/edgeadm/cmd/addon/edgeapps.go
@@ -82,6 +82,6 @@ func (a *addonAction) runAddon() error {
 }
 
 func (a *addonAction) runDetach() error {
-	klog.Info("Start install addon apps to your original cluster")
+	klog.Info("Start uninstall addon apps from your original cluster")
 	return common.DeleteEdgeAPPS(a.clientSet, a.manifestDir, a.caCertFile, a.caKeyFile, a.masterPublicAddr, a.certSANs)
 }

--- a/pkg/edgeadm/common/update_config.go
+++ b/pkg/edgeadm/common/update_config.go
@@ -38,12 +38,12 @@ import (
 // runCoreDNSAddon installs CoreDNS addon to a Kubernetes cluster
 func UpdateKubeConfig(client *kubernetes.Clientset) error {
 	if err := UpdateKubeProxyKubeconfig(client); err != nil {
-		klog.Errorf("Deploy serivce group, error: %s", err)
+		klog.Errorf("Update kube-proxy kubeconfig, error: %s", err)
 		return err
 	}
 
 	if err := UpdateKubernetesEndpoint(client); err != nil {
-		klog.Errorf("Deploy serivce group, error: %s", err)
+		klog.Errorf("Update kubernetes endpoint, error: %s", err)
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: lianghao208 <302824716@qq.com>

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
an enhancement feature


**What this PR does**:
`edgeadm token create --print-joint-command` get master ip from cluster-info
```
# edgeadm token create --print-joint-command
edgeadm join <master IP from cluster-info>:<port> --token xxx    --discovery-token-ca-cert-hash sha256:xxx
```

**Special notes for your reviewer**:

@attlee-wang 