### PR TITLE
Add the POD_NAME environment variable to the deployment of tunnel-cloud

### DIFF
--- a/pkg/edgeadm/constant/manifests/tunnel-cloud.go
+++ b/pkg/edgeadm/constant/manifests/tunnel-cloud.go
@@ -178,6 +178,11 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
           volumeMounts:
             - name: token
               mountPath: /etc/superedge/tunnel/token


### PR DESCRIPTION

**What type of PR is this?**
kind/bug
**What this PR does**:
Add the POD_NAME environment variable to the deployment of tunnel-cloud
**Which issue(s) this PR fixes**:
The custom metrics of the pod type of tunnel cloud are empty
