### PR TITLE
Fix error message does not match with dupReadCloser name

### DIFF
--- a/pkg/lite-apiserver/proxy/util.go
+++ b/pkg/lite-apiserver/proxy/util.go
@@ -69,7 +69,7 @@ func (dr *dupReadCloser) Read(p []byte) (n int, err error) {
 	n, err = dr.rc.Read(p)
 	if n > 0 {
 		if n, err := dr.pw.Write(p[:n]); err != nil {
-			klog.Errorf("dualReader: failed to write %v", err)
+			klog.Errorf("dupReader: failed to write %v", err)
 			return n, err
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
/kind enhancement

**What this PR does**:
- background:
1.  It is obvious that `dupReadCloser` implementation in https://github.com/superedge/superedge/blob/main/pkg/lite-apiserver/proxy/util.go#L52-L96 comes from `dualReadCloser` in OpenYurt(https://github.com/openyurtio/openyurt/blob/master/pkg/yurthub/util/util.go#L200-L266), but some error messages with `dualReadCloser` have not been fully modified.

![image](https://user-images.githubusercontent.com/57081505/133784289-7bda610b-746c-45d4-81ff-909a13ef9475.png)

2. the design of `dualReadCloser`, you can refer to the link here: https://mp.weixin.qq.com/s/vdFrCDiIhPLVbOnf6vRxEw

- solution:
 fix error message does not match with dupReadCloser.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

