### PR TITLE
add judge before use the arrary's index

### DIFF
--- a/pkg/tunnel/token/tokencache.go
+++ b/pkg/tunnel/token/tokencache.go
@@ -125,5 +125,8 @@ func ParseToken(token string) (*Token, error) {
 func ParseLine(line string, m map[string]string) {
 	line = util.ReplaceString(line)
 	kv := strings.Split(line, ":")
+	if len(kv) < 2{
+		return
+	}
 	m[kv[0]] = kv[1]
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
bug

**What this PR does**:
add judge before use the arrary's index. if the length is lower than 2 ,then kv[1] will panic

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

