### PR TITLE
edge-health: add ut

### DIFF
--- a/pkg/edge-health/checkplugin/checkplugin_test.go
+++ b/pkg/edge-health/checkplugin/checkplugin_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checkplugin
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestBasePlugin_SetWeight(t *testing.T) {
+	testcases := []struct {
+		weight         float64
+		expectedweight float64
+	}{
+		{
+			weight:         1.5,
+			expectedweight: 1.5,
+		},
+		{
+			weight:         3.0,
+			expectedweight: 3.0,
+		},
+	}
+	for _, tc := range testcases {
+		baseplugin := NewBasePlugin(5, 5, 80, tc.weight, "test")
+		setvalue := tc.weight + float64(3)
+		baseplugin.SetWeight(setvalue)
+		if baseplugin.GetWeight() != tc.expectedweight {
+			t.Fatal("unexpected error, actual weight is ", baseplugin.GetWeight())
+		}
+	}
+}
+
+func TestPingDo(t *testing.T) {
+	testcases := []struct {
+		description string
+		url         string
+		result      bool
+	}{
+		{
+			description: "request github",
+			url:         "https://github.com/",
+			result:      true,
+		},
+		{
+			description: "request url which not exist",
+			url:         "http://notexistrealdomainip/notrealpath",
+			result:      false,
+		},
+	}
+	client := http.Client{Timeout: time.Duration(10) * time.Second}
+
+	for _, tc := range testcases {
+		t.Log("now prepare to run", tc.description)
+		req, err := http.NewRequest("HEAD", tc.url, nil)
+		if err != nil {
+			t.Fatal("unexpected reuqest")
+		}
+
+		result, err := PingDo(client, req)
+		if result != tc.result {
+			t.Fatal("unexpected error, actual result and err is", tc.result, err)
+		}
+	}
+}

--- a/pkg/edge-health/checkplugin/kubeletauthcheck_test.go
+++ b/pkg/edge-health/checkplugin/kubeletauthcheck_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package checkplugin
+
+import (
+	"testing"
+)
+
+func TestKubeletCheckPlugin_Set(t *testing.T) {
+	k := KubeletAuthCheckPlugin{}
+
+	testcases := []struct {
+		description               string
+		parameter                 string
+		result                    int
+		expectedtimeout           int
+		expecteretrytimeretrytime int
+		error                     error
+	}{
+		{
+			description: "wrong parameter format",
+			parameter:   " ",
+			result:      1,
+			error:       nil,
+		},
+		{
+			description: "wrong timeout",
+			parameter:   "time=5",
+			result:      1,
+			error:       nil,
+		},
+		{
+			description:               "pass timeout, retrytime and weight",
+			parameter:                 "timeout=5, retrytime=10, weight=1.0",
+			result:                    1,
+			expectedtimeout:           5,
+			expecteretrytimeretrytime: 10,
+			error:                     nil,
+		},
+	}
+	for _, tc := range testcases {
+		t.Log("prepare to run", tc.description)
+
+		err := k.Set(tc.parameter)
+		if err != tc.error || k.HealthCheckoutTimeOut != tc.expectedtimeout || k.HealthCheckRetryTime != tc.expecteretrytimeretrytime {
+			t.Fatal("unexpected err", err)
+		}
+	}
+}

--- a/pkg/edge-health/data/checkinfodata_test.go
+++ b/pkg/edge-health/data/checkinfodata_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package data
+
+import (
+	"testing"
+)
+
+func TestCheckInfoData_SetCheckInfo(t *testing.T) {
+	checkInfoData := NewCheckInfoData()
+	checkInfoData.SetCheckInfo("10.0.0.1", "test", 1.5, 10)
+
+	if checkInfoData.CheckInfo["10.0.0.1"]["test"] != 15 {
+		t.Fatal("unexpected error")
+	}
+}
+
+func TestCheckInfoData_SetCheckedIpCheckInfo(t *testing.T) {
+	checkInfoData := NewCheckInfoData()
+	checkInfoData.SetCheckedIpCheckInfo("10.0.0.1")
+	if _, ok := checkInfoData.CheckInfo["10.0.0.1"]; !ok {
+		t.Fatal("unexpected error")
+	}
+}
+
+func TestCheckInfoData_TraverseCheckedIpCheckInfo(t *testing.T) {
+	checkInfoData := NewCheckInfoData()
+	checkInfoData.SetCheckInfo("10.0.0.1", "test", 1.5, 10)
+	result := checkInfoData.TraverseCheckedIpCheckInfo()
+
+	if result[0] != "10.0.0.1" {
+		t.Fatal("unexpected error")
+	}
+
+}

--- a/pkg/edge-health/data/configmapdata_test.go
+++ b/pkg/edge-health/data/configmapdata_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2022 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package data
+
+import (
+	"github.com/superedge/superedge/test"
+	v1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestConfigMapListData_SetConfigListData(t *testing.T) {
+	configMapListData := NewConfigMapListData()
+
+	cm1 := test.BuildTestConfigmap("cm1", "default", map[string]string{"username": "admin"})
+	testcases := []struct {
+		description string
+		obj         v1.ConfigMap
+		expecteNum  int
+	}{
+		{
+			description: "add one configmap",
+			obj:         *cm1,
+			expecteNum:  1,
+		},
+	}
+	for _, tc := range testcases {
+		configMapListData.SetConfigListData(tc.obj)
+		if len(configMapListData.ConfigMapList.Items) != tc.expecteNum {
+			t.Fatal("unexpected result , should set configmap to ConfigMapList")
+		}
+	}
+
+}
+
+func TestConfigMapListData_DeleteConfigListData(t *testing.T) {
+	configMapListData := NewConfigMapListData()
+	cm1 := test.BuildTestConfigmap("cm1", "default", map[string]string{"username": "admin"})
+	cm2 := test.BuildTestConfigmap("cm2", "default", map[string]string{"password": "passwd"})
+	configMapListData.SetConfigListData(*cm1)
+	configMapListData.SetConfigListData(*cm2)
+	if len(configMapListData.ConfigMapList.Items) != 2 {
+		t.Fatal("unexpected result , should set configmap to ConfigMapList")
+	}
+	configMapListData.DeleteConfigListData(*cm2)
+	if len(configMapListData.ConfigMapList.Items) != 1 {
+		t.Fatal("unexpected result , should delete configmap success")
+	}
+
+}

--- a/pkg/edge-health/data/nodelistdata_test.go
+++ b/pkg/edge-health/data/nodelistdata_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package data
+
+import (
+	"github.com/superedge/superedge/test"
+	"k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestNodeListData_SetNodeListDataByNode(t *testing.T) {
+	nodeListData := NewNodeListData()
+	node1 := test.BuildTestNode("node1", 1000, 2000, 9, nil)
+
+	testcases := []struct {
+		description string
+		nodes       []v1.Node
+		result      int
+	}{
+		{
+			description: "add one node into node list",
+			nodes:       []v1.Node{*node1},
+			result:      1,
+		},
+	}
+
+	for _, tc := range testcases {
+		for _, node := range tc.nodes {
+			t.Log("now prepare to run", tc.description)
+			nodeListData.SetNodeListDataByNode(node)
+
+			t.Log(len(nodeListData.NodeList.Items))
+			if len(nodeListData.NodeList.Items) != tc.result {
+				t.Fatal("unexpected result")
+			}
+		}
+	}
+}
+
+func TestNodeListData_DeleteNodeListDataByNode(t *testing.T) {
+	nodeListData := NewNodeListData()
+	node1 := test.BuildTestNode("node1", 1000, 2000, 9, nil)
+	nodeListData.SetNodeListDataByNode(*node1)
+	if len(nodeListData.NodeList.Items) != 1 {
+		t.Fatal("insert node into nodeList fail")
+	}
+
+	nodeListData.DeleteNodeListDataByNode(*node1)
+	if len(nodeListData.NodeList.Items) != 0 {
+		t.Fatal("delete node into nodeList fail")
+	}
+}
+
+func TestNodeListData_CopyNodeListData(t *testing.T) {
+	nodeListData := NewNodeListData()
+	node1 := test.BuildTestNode("node1", 1000, 2000, 9, nil)
+	node2 := test.BuildTestNode("node2", 1000, 2000, 9, nil)
+	nodeListData.SetNodeListDataByNode(*node1)
+	nodeListData.SetNodeListDataByNode(*node2)
+
+	if nodeListData.GetLenListData() != 2 {
+		t.Fatal("unexpected result, wrong insert data")
+	}
+
+	nodelist := nodeListData.CopyNodeListData()
+	if len(nodelist) != 2 {
+		t.Fatal("unexpected copy, wrong nodes len")
+	}
+}

--- a/pkg/edge-health/data/resultdata.go
+++ b/pkg/edge-health/data/resultdata.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The SuperEdge Authors.
+Copyright 2022 The SuperEdge Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/edge-health/util/util_test.go
+++ b/pkg/edge-health/util/util_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/superedge/superedge/test"
+	"k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestGetHmacCode(t *testing.T) {
+	testcases := []struct {
+		parastring string
+		parakey    string
+		expect     string
+		error      error
+	}{
+		{
+			parastring: "abcde",
+			parakey:    "12345",
+			expect:     "f8f78e4c506669fdd116876d08adf809ed7c33585078dcfd4e6fe863b7ea966a",
+			error:      nil,
+		},
+		{
+			parastring: "helloworld",
+			parakey:    "passkey",
+			expect:     "b33350ac6988d60bf85739f71f73df3b2252a20ee650d271e34ca5799b8a5334",
+			error:      nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		result, err := GetHmacCode(tc.parastring, tc.parakey)
+
+		if err != tc.error || result != tc.expect {
+			t.Fatal("unexpected error", err)
+		}
+	}
+
+}
+
+func TestGetNodeNameByIp(t *testing.T) {
+	node1 := test.BuildTestNode("node1", 1000, 2000, 9, nil)
+	node2 := test.BuildTestNode("node2", 1000, 2000, 9, nil)
+	nodelist := []v1.Node{*node1, *node2}
+
+	result := GetNodeNameByIp(nodelist, "10.0.0.1")
+	if result != "" {
+		t.Fatal("unexpected err")
+	}
+}

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BuildTestNode creates a node with specified capacity.
+func BuildTestNode(name string, millicpu int64, mem int64, pods int64, apply func(*v1.Node)) *v1.Node {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:     name,
+			SelfLink: fmt.Sprintf("/api/v1/nodes/%s", name),
+			Labels:   map[string]string{},
+		},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourcePods:   *resource.NewQuantity(pods, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(millicpu, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(mem, resource.DecimalSI),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourcePods:   *resource.NewQuantity(pods, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(millicpu, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(mem, resource.DecimalSI),
+			},
+			Phase: v1.NodeRunning,
+			Conditions: []v1.NodeCondition{
+				{Type: v1.NodeReady, Status: v1.ConditionTrue},
+			},
+		},
+	}
+	if apply != nil {
+		apply(node)
+	}
+	return node
+}
+
+func BuildTestPod(name string, cpu int64, memory int64, nodeName string, apply func(*v1.Pod)) *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+			SelfLink:  fmt.Sprintf("/api/v1/namespaces/default/pods/%s", name),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{},
+						Limits:   v1.ResourceList{},
+					},
+				},
+			},
+			NodeName: nodeName,
+		},
+	}
+	if cpu >= 0 {
+		pod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU] = *resource.NewMilliQuantity(cpu, resource.DecimalSI)
+	}
+	if memory >= 0 {
+		pod.Spec.Containers[0].Resources.Requests[v1.ResourceMemory] = *resource.NewQuantity(memory, resource.DecimalSI)
+	}
+	if apply != nil {
+		apply(pod)
+	}
+	return pod
+}
+
+func BuildTestConfigmap(name string, namespace string, data map[string]string) *v1.ConfigMap {
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Data: data,
+	}
+	return cm
+}


### PR DESCRIPTION
To improve ut coverage, already test in my latop


```
jane@JanedeMacBook-Pro edge-health % go test ./...
go: downloading github.com/spf13/pflag v1.0.5
go: downloading k8s.io/component-base v0.20.5
go: downloading github.com/imdario/mergo v0.3.12
go: downloading github.com/google/go-cmp v0.5.5
go: downloading github.com/hashicorp/golang-lru v0.5.3
?   	github.com/superedge/superedge/pkg/edge-health/check	[no test files]
ok  	github.com/superedge/superedge/pkg/edge-health/checkplugin	2.924s
?   	github.com/superedge/superedge/pkg/edge-health/common	[no test files]
?   	github.com/superedge/superedge/pkg/edge-health/communicate	[no test files]
ok  	github.com/superedge/superedge/pkg/edge-health/daemon	1.158s [no tests to run]
ok  	github.com/superedge/superedge/pkg/edge-health/data	1.943s
```
**What type of PR is this?**

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

