### PR TITLE
edge-health: support extendable check plugin

### DIFF
--- a/cmd/edge-health/app/server.go
+++ b/cmd/edge-health/app/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"github.com/spf13/cobra"
 	"github.com/superedge/superedge/cmd/edge-health/app/options"
+	"github.com/superedge/superedge/pkg/edge-health/checkplugin"
 	"github.com/superedge/superedge/pkg/edge-health/common"
 	"github.com/superedge/superedge/pkg/edge-health/daemon"
 	"github.com/superedge/superedge/pkg/util"
@@ -28,7 +29,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func NewEdgeHealthCommand(ctx context.Context) *cobra.Command {
+type ExtendOptions func() checkplugin.Registry
+
+func NewEdgeHealthCommand(ctx context.Context, registryOptions ...ExtendOptions) *cobra.Command {
 	o := options.NewEdgeHealthOptions()
 	cmd := &cobra.Command{
 		Use: common.CmdName,
@@ -43,7 +46,7 @@ func NewEdgeHealthCommand(ctx context.Context) *cobra.Command {
 				klog.Fatalf("options validate err: %v", errs)
 			}
 
-			daemon.NewEdgeHealthDaemon(completedOptions).Run(ctx)
+			daemon.NewEdgeHealthDaemon(completedOptions, registryOptions...).Run(ctx)
 		},
 	}
 	fs := cmd.Flags()

--- a/pkg/edge-health/checkplugin/checkplugin.go
+++ b/pkg/edge-health/checkplugin/checkplugin.go
@@ -19,9 +19,9 @@ package checkplugin
 import (
 	"fmt"
 	"io/ioutil"
-	"k8s.io/klog/v2"
 	"net/http"
 	"sync"
+        "k8s.io/klog/v2"
 )
 
 type CheckPlugin interface {
@@ -30,6 +30,22 @@ type CheckPlugin interface {
 	SetWeight(float64)
 	GetWeight() float64
 }
+type PluginFactory = func() (CheckPlugin, error)
+
+type Registry map[string]PluginFactory
+
+func Merge(outOfTree Registry) error {
+	for name, factory := range outOfTree {
+		checkplugin, err := factory()
+		if err != nil {
+			return err
+		}
+		PluginInfo = NewPluginInfo()
+		PluginInfo.AddPlugin(checkplugin)
+		klog.V(4).Info("add plugin success", name)
+	}
+	return nil
+}
 
 type BasePlugin struct {
 	PluginName            string
@@ -37,6 +53,7 @@ type BasePlugin struct {
 	HealthCheckRetryTime  int
 	Weight                float64 //ex:0.3
 	Port                  int
+	Enabled               bool
 }
 
 func (p BasePlugin) SetWeight(weight float64) {
@@ -79,6 +96,8 @@ func NewPluginInfo() Plugin {
 func (p *Plugin) AddPlugin(plugin CheckPlugin) {
 	PluginMu.Lock()
 	defer PluginMu.Unlock()
+	// TODO: should check plugin is it exist or not, now have a logic bug
+	// plugins can be add many times since it is only a slice, you could check on the ut TestMerge
 	p.Plugins = append(p.Plugins, plugin)
 	klog.V(4).Info("add ok")
 }

--- a/pkg/edge-health/checkplugin/kubeletcheck.go
+++ b/pkg/edge-health/checkplugin/kubeletcheck.go
@@ -36,6 +36,10 @@ func (p KubeletCheckPlugin) Name() string {
 	return "KubeletCheck"
 }
 
+func (p KubeletCheckPlugin) Enable() bool {
+	return p.Enabled
+}
+
 func (p *KubeletCheckPlugin) Set(s string) error {
 	var (
 		err error

--- a/pkg/edge-health/checkplugin/pingcheck.go
+++ b/pkg/edge-health/checkplugin/pingcheck.go
@@ -36,6 +36,10 @@ func (p PingCheckPlugin) Name() string {
 	return "PingCheck"
 }
 
+func (p PingCheckPlugin) Enable() bool {
+	return p.Enabled
+}
+
 func (p *PingCheckPlugin) Set(s string) error {
 	var (
 		err error


### PR DESCRIPTION
Implement the plugin interface of their own strategy as a plugin factory to tell superedge to add the plugins.
Register the plugins as a parameter by calling NewEdgeHealthCommand.
The inspiration is from kube-scheduler out-of-tree plugin registry. The project scheduler-plugin is based on this cool function. It adds new scheduler plugins without modifying any source codes in kube-scheduler.

Fixes #316

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

