### PR TITLE
Feature: Support resource cache multiplex in lite-apiserver

### DIFF
--- a/pkg/lite-apiserver/config/config.go
+++ b/pkg/lite-apiserver/config/config.go
@@ -49,13 +49,14 @@ type LiteServerConfig struct {
 
 	ModifyRequestAccept bool
 
-	CacheType        string
-	FileCachePath    string
-	BadgerCachePath  string
-	BoltCacheFile    string
-	PebbleCachePath  string
-	NetworkInterface string
-	Insecure         bool
+	CacheType         string
+	FileCachePath     string
+	BadgerCachePath   string
+	BoltCacheFile     string
+	PebbleCachePath   string
+	NetworkInterface  string
+	Insecure          bool
+	URLMultiplexCache []string
 }
 
 type TLSKeyPair struct {

--- a/pkg/lite-apiserver/server/multiplex/endpoint_cache.go
+++ b/pkg/lite-apiserver/server/multiplex/endpoint_cache.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplex
+
+import (
+	"net/http"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// EndpointCacheURL is cached url
+	EndpointCacheURL = "/api/v1/endpoints"
+)
+
+func init() {
+	RegisterMuxFactory(EndpointCacheURL, &endpointCacheMuxFactory{})
+}
+
+type endpointCacheMuxFactory struct{}
+
+var _ CacheMuxFactory = &endpointCacheMuxFactory{}
+
+func (f *endpointCacheMuxFactory) Create(hostname string, informerFactory informers.SharedInformerFactory) (CacheMux, error) {
+	return NewEndpointMux(hostname, informerFactory)
+}
+
+type endpointMux struct {
+	hostname    string
+	broadcaster *watch.Broadcaster
+	epInformer  cache.SharedIndexInformer
+	epLister    listerv1.EndpointsLister
+}
+
+var _ CacheMux = &endpointMux{}
+
+// NewEndpointMux ...
+func NewEndpointMux(hostname string, informerFactory informers.SharedInformerFactory) (CacheMux, error) {
+	ba := watch.NewLongQueueBroadcaster(maxQueuedEvents, watch.DropIfChannelFull)
+	informer := informerFactory.Core().V1().Endpoints()
+	epMux := &endpointMux{
+		hostname:    hostname,
+		broadcaster: ba,
+		epInformer:  informer.Informer(),
+		epLister:    informer.Lister(),
+	}
+	// don't resync to downstream watchers
+	informer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc:    epMux.OnAdd,
+		UpdateFunc: epMux.OnUpdate,
+		DeleteFunc: epMux.OnDelete,
+	}, 0)
+
+	// run with informerFactory
+
+	// stop := make(chan struct{})
+	// go informer.Informer().Run(stop)
+	// if !cache.WaitForNamedCacheSync("endpointMux", stop, informer.Informer().HasSynced) {
+	// 	return nil, fmt.Errorf("can't sync informers")
+	// }
+
+	return epMux, nil
+}
+
+func (em *endpointMux) Name() string {
+	return EndpointCacheURL
+}
+
+func (em *endpointMux) Match(method, URLPath string) bool {
+	if method == http.MethodGet && strings.HasPrefix(URLPath, EndpointCacheURL) {
+		return true
+	}
+	return false
+}
+
+// watch will ignore resourceVersion and return all
+func (em *endpointMux) Watch(bookmark bool, ResourceVersion string) (watch.Interface, error) {
+	// list all obj in all namespaces
+	eps, err := em.epLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("List endpoints error by endpoint lister, will drop first, err %v", err)
+		return nil, err
+	}
+	// build ADD event
+	// TODO deal with resourceVersion param
+	evList := make([]watch.Event, 0, len(eps))
+	for _, ep := range eps {
+		evList = append(evList, watch.Event{Type: watch.Added, Object: ep})
+	}
+
+	// broadcast watch with prefix
+	return em.broadcaster.WatchWithPrefix(evList), nil
+}
+
+func (em *endpointMux) ListObjects(selector labels.Selector, appendFn cache.AppendFunc) error {
+	store := em.epInformer.GetStore()
+	return cache.ListAll(store, selector, appendFn)
+}
+
+func (em *endpointMux) OnAdd(obj interface{}) {
+	eps, ok := obj.(*v1.Endpoints)
+	if !ok {
+		return
+	}
+	em.broadcaster.Action(watch.Added, eps)
+}
+
+func (em *endpointMux) OnUpdate(oldObj interface{}, newObj interface{}) {
+	eps, ok := newObj.(*v1.Endpoints)
+	if !ok {
+		return
+	}
+	em.broadcaster.Action(watch.Modified, eps)
+}
+
+func (em *endpointMux) OnDelete(obj interface{}) {
+	eps, ok := obj.(*v1.Endpoints)
+	if !ok {
+		return
+	}
+	em.broadcaster.Action(watch.Deleted, eps)
+}

--- a/pkg/lite-apiserver/server/multiplex/endpoint_cache_test.go
+++ b/pkg/lite-apiserver/server/multiplex/endpoint_cache_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplex
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	clientscheme "k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiwatch "k8s.io/apimachinery/pkg/watch"
+	utiltesting "k8s.io/client-go/util/testing"
+)
+
+var emptyNodeName = "nil"
+
+func makeTestServer(t *testing.T) (*httptest.Server, *utiltesting.FakeHandler) {
+	fakeEndpointsHandler := utiltesting.FakeHandler{
+		StatusCode:   http.StatusOK,
+		ResponseBody: runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{}),
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/api/v1/endpoints", &fakeEndpointsHandler)
+	mux.Handle("/api/v1/endpoints/", &fakeEndpointsHandler)
+	mux.HandleFunc("/", func(res http.ResponseWriter, req *http.Request) {
+		t.Errorf("unexpected request: %v", req.RequestURI)
+		http.Error(res, "", http.StatusNotFound)
+	})
+	return httptest.NewServer(mux), &fakeEndpointsHandler
+}
+
+func newSharedInformerFactory(url string) informers.SharedInformerFactory {
+	client := clientset.NewForConfigOrDie(&restclient.Config{Host: url, ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+	return informerFactory
+}
+
+func TestEndpointMuxWatch(t *testing.T) {
+	testServer, _ := makeTestServer(t)
+
+	mux, err := NewEndpointMux("testnode", newSharedInformerFactory(testServer.URL))
+	if err != nil {
+		t.Fatalf("NewEndpointMux returned unexpected error %v", err)
+	}
+	epmux := mux.(*endpointMux)
+
+	storecase := []*v1.Endpoints{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "store1",
+				Namespace:       "defalut",
+				ResourceVersion: "1",
+			},
+			Subsets: []v1.EndpointSubset{{
+				Addresses: []v1.EndpointAddress{{IP: "1.2.3.4", NodeName: &emptyNodeName}},
+				Ports:     []v1.EndpointPort{{Port: 1000, Protocol: "TCP"}},
+			}},
+		},
+	}
+	epmux.epInformer.GetStore().Add(storecase[0])
+
+	watchcase := []apiwatch.Event{
+		{
+			Type: apiwatch.Added,
+			Object: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "foo",
+					Namespace:       "defalut",
+					ResourceVersion: "1",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Addresses: []v1.EndpointAddress{{IP: "6.7.8.9", NodeName: &emptyNodeName}},
+					Ports:     []v1.EndpointPort{{Port: 1000, Protocol: "TCP"}},
+				}},
+			}},
+		{
+			Type: apiwatch.Added,
+			Object: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "foo1",
+					Namespace:       "defalut",
+					ResourceVersion: "1",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Addresses: []v1.EndpointAddress{{IP: "1.1.1.1", NodeName: &emptyNodeName}},
+					Ports:     []v1.EndpointPort{{Port: 1000, Protocol: "TCP"}},
+				}},
+			}},
+		{
+			Type: apiwatch.Modified,
+			Object: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "foo2",
+					Namespace:       "defalut",
+					ResourceVersion: "1",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Addresses: []v1.EndpointAddress{{IP: "2.2.2.2", NodeName: &emptyNodeName}},
+					Ports:     []v1.EndpointPort{{Port: 1000, Protocol: "TCP"}},
+				}},
+			}},
+		{
+			Type: apiwatch.Deleted,
+			Object: &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "foo3",
+					Namespace:       "defalut",
+					ResourceVersion: "1",
+				},
+				Subsets: []v1.EndpointSubset{{
+					Addresses: []v1.EndpointAddress{{IP: "3.3.3.3", NodeName: &emptyNodeName}},
+					Ports:     []v1.EndpointPort{{Port: 1000, Protocol: "TCP"}},
+				}},
+			}},
+	}
+	table := []apiwatch.Event{
+		{
+			Type:   apiwatch.Added,
+			Object: storecase[0],
+		},
+	}
+	table = append(table, watchcase...)
+	const testWatchers = 2
+	wg := sync.WaitGroup{}
+	wg.Add(testWatchers)
+	for i := 0; i < testWatchers; i++ {
+		w, err := mux.Watch(false, "")
+		if err != nil {
+			t.Fatalf("mux.Watch() returned unexpected error %v", err)
+		}
+		go func(watcher int, w apiwatch.Interface) {
+			tableLine := 0
+			for {
+				// the event is from store first
+				event, ok := <-w.ResultChan()
+				if !ok {
+					break
+				}
+				if e, a := table[tableLine], event; !reflect.DeepEqual(e, a) {
+					t.Errorf("Watcher %v, line %v: Expected (%v, %#v), got (%v, %#v)",
+						watcher, tableLine, e.Type, e.Object, a.Type, a.Object)
+				} else {
+					t.Logf("watcher %d Got (%v, %#v)", watcher, event.Type, event.Object)
+				}
+				tableLine++
+			}
+			wg.Done()
+		}(i, w)
+	}
+
+	epmux.OnAdd(table[1].Object)
+	epmux.OnAdd(table[2].Object)
+	epmux.OnUpdate(nil, table[3].Object)
+	epmux.OnDelete(table[4].Object)
+	epmux.broadcaster.Shutdown()
+
+	wg.Wait()
+}
+
+func TestEndpointMuxListObjects(t *testing.T) {
+	testServer, _ := makeTestServer(t)
+
+	mux, err := NewEndpointMux("testnode", newSharedInformerFactory(testServer.URL))
+	if err != nil {
+		t.Fatalf("NewEndpointMux returned unexpected error %v", err)
+	}
+	epmux := mux.(*endpointMux)
+
+	storecase := []*v1.Endpoints{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "store1",
+				Namespace:       "defalut",
+				ResourceVersion: "1",
+				Labels:          map[string]string{"foo": "bar"},
+			},
+			Subsets: []v1.EndpointSubset{{
+				Addresses: []v1.EndpointAddress{{IP: "1.2.3.4", NodeName: &emptyNodeName}},
+				Ports:     []v1.EndpointPort{{Port: 1000, Protocol: "TCP"}},
+			}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "store2",
+				Namespace:       "defalut",
+				ResourceVersion: "1",
+				Labels:          map[string]string{"foo1": "bar1"},
+			},
+			Subsets: []v1.EndpointSubset{{
+				Addresses: []v1.EndpointAddress{{IP: "2.2.3.4", NodeName: &emptyNodeName}},
+				Ports:     []v1.EndpointPort{{Port: 1000, Protocol: "TCP"}},
+			}},
+		},
+	}
+	for _, e := range storecase {
+		epmux.epInformer.GetStore().Add(e)
+	}
+	var eps1 []*v1.Endpoints
+	epmux.ListObjects(labels.Everything(), func(m interface{}) {
+		eps1 = append(eps1, m.(*v1.Endpoints))
+	})
+	if len(eps1) != 2 {
+		t.Errorf("ListObject count error Expected  (%d), got (%d)", len(storecase), len(eps1))
+	}
+
+	var eps2 []*v1.Endpoints
+	label, _ := labels.Parse("foo=bar")
+	epmux.ListObjects(label, func(m interface{}) {
+		eps2 = append(eps2, m.(*v1.Endpoints))
+	})
+	if len(eps2) != 1 {
+		t.Errorf("ListObject count error Expected  (%d), got (%d)", 1, len(eps2))
+	}
+
+}

--- a/pkg/lite-apiserver/server/multiplex/factory.go
+++ b/pkg/lite-apiserver/server/multiplex/factory.go
@@ -1,0 +1,55 @@
+package multiplex
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/klog/v2"
+)
+
+var muxFactories = make(map[string]CacheMuxFactory)
+var muxRegistries = make(map[string]CacheMux)
+
+type CacheMuxFactory interface {
+	Create(hostname string, informerFactory informers.SharedInformerFactory) (CacheMux, error)
+}
+
+func RegisterMuxFactory(url string, f CacheMuxFactory) {
+	if f == nil {
+		panic("Must provide valid CacheMuxFactory")
+	}
+	_, registered := muxFactories[url]
+	if registered {
+		panic(fmt.Sprintf("CacheMuxFactory url %s already registered", url))
+	}
+
+	muxFactories[url] = f
+}
+
+func CreateMux(url, hostname string, informerFactory informers.SharedInformerFactory) (CacheMux, error) {
+	muxFactory, ok := muxFactories[url]
+	if !ok {
+		return nil, fmt.Errorf("Unsupport Multiplex URL %s", url)
+	}
+	return muxFactory.Create(hostname, informerFactory)
+}
+func GetMuxFactory(url string) (CacheMuxFactory, error) {
+	muxFactory, ok := muxFactories[url]
+	if !ok {
+		return nil, fmt.Errorf("Unsupport Multiplex URL %s", url)
+	}
+	return muxFactory, nil
+}
+
+func GetMux(url string) (CacheMux, error) {
+	mux, ok := muxRegistries[url]
+	if !ok {
+		return nil, fmt.Errorf("Unregister Multiplex URL")
+	}
+	return mux, nil
+}
+
+func RegisterMux(url string, mux CacheMux) {
+	klog.V(4).Infof("Register URL %s for mux cache", url)
+	muxRegistries[url] = mux
+}

--- a/pkg/lite-apiserver/server/multiplex/muxserver.go
+++ b/pkg/lite-apiserver/server/multiplex/muxserver.go
@@ -1,0 +1,20 @@
+package multiplex
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+const maxQueuedEvents = 1000
+
+type CacheMux interface {
+	Name() string
+	// Match check the resource url if need multiplex
+	Match(method, URLPath string) bool
+	// Watch return a event chan from upstream apiserver
+	Watch(bookmark bool, ResourceVersion string) (watch.Interface, error)
+	// ListObjects list object from informer store, labels filter in store.ListAll
+	// field filter will in downstream
+	ListObjects(selector labels.Selector, appendFn cache.AppendFunc) error
+}

--- a/pkg/lite-apiserver/server/multiplex/node_cache.go
+++ b/pkg/lite-apiserver/server/multiplex/node_cache.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplex
+
+import (
+	"net/http"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// NodeCacheURL is cached url
+	NodeCacheURL = "/api/v1/nodes"
+)
+
+func init() {
+	RegisterMuxFactory(NodeCacheURL, &nodeCacheMuxFactory{})
+}
+
+type nodeCacheMuxFactory struct{}
+
+var _ CacheMuxFactory = &nodeCacheMuxFactory{}
+
+func (f *nodeCacheMuxFactory) Create(hostname string, informerFactory informers.SharedInformerFactory) (CacheMux, error) {
+	return NewNodeMux(hostname, informerFactory)
+}
+
+type nodeMux struct {
+	hostname     string
+	broadcaster  *watch.Broadcaster
+	nodeInformer cache.SharedIndexInformer
+	nodeLister   listerv1.NodeLister
+}
+
+var _ CacheMux = &nodeMux{}
+
+// NewNodeMux ...
+func NewNodeMux(hostname string, informerFactory informers.SharedInformerFactory) (CacheMux, error) {
+	ba := watch.NewLongQueueBroadcaster(maxQueuedEvents, watch.DropIfChannelFull)
+	informer := informerFactory.Core().V1().Nodes()
+	nodeMux := &nodeMux{
+		hostname:     hostname,
+		broadcaster:  ba,
+		nodeInformer: informer.Informer(),
+		nodeLister:   informer.Lister(),
+	}
+	// don't resync to downstream watchers
+	informer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc:    nodeMux.OnAdd,
+		UpdateFunc: nodeMux.OnUpdate,
+		DeleteFunc: nodeMux.OnDelete,
+	}, 0)
+
+	return nodeMux, nil
+}
+
+func (nm *nodeMux) Name() string {
+	return NodeCacheURL
+}
+
+func (nm *nodeMux) Match(method, URLPath string) bool {
+	if method == http.MethodGet && strings.HasPrefix(URLPath, NodeCacheURL) {
+		return true
+	}
+	return false
+}
+
+// watch will ignore resourceVersion and return all
+func (nm *nodeMux) Watch(bookmark bool, ResourceVersion string) (watch.Interface, error) {
+	// list all obj in all namespaces
+	nodes, err := nm.nodeLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("List node error by node lister, will drop first, err %v", err)
+		return nil, err
+	}
+	klog.V(4).Infof("WatchWithPrefix node list length %v", len(nodes))
+	// build ADD event
+	// TODO deal with resourceVersion param
+	// sort obj by resourceVersion
+	// index by resourceVersion
+	evList := make([]watch.Event, 0, len(nodes))
+	for _, n := range nodes {
+		evList = append(evList, watch.Event{Type: watch.Added, Object: n})
+	}
+
+	// broadcast watch with prefix
+	return nm.broadcaster.WatchWithPrefix(evList), nil
+}
+
+func (nm *nodeMux) ListObjects(selector labels.Selector, appendFn cache.AppendFunc) error {
+	store := nm.nodeInformer.GetStore()
+	return cache.ListAll(store, selector, appendFn)
+}
+
+func (nm *nodeMux) OnAdd(obj interface{}) {
+	n, ok := obj.(*v1.Node)
+	if !ok {
+		return
+	}
+	nm.broadcaster.Action(watch.Added, n)
+}
+
+func (nm *nodeMux) OnUpdate(oldObj interface{}, newObj interface{}) {
+	n, ok := newObj.(*v1.Node)
+	if !ok {
+		return
+	}
+	nm.broadcaster.Action(watch.Modified, n)
+}
+
+func (nm *nodeMux) OnDelete(obj interface{}) {
+	n, ok := obj.(*v1.Node)
+	if !ok {
+		return
+	}
+	nm.broadcaster.Action(watch.Deleted, n)
+}

--- a/pkg/lite-apiserver/server/multiplex/node_cache_test.go
+++ b/pkg/lite-apiserver/server/multiplex/node_cache_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplex
+
+// Node cache mux is extremely same with Endpoint test

--- a/pkg/lite-apiserver/server/multiplex/service_cache.go
+++ b/pkg/lite-apiserver/server/multiplex/service_cache.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file excsvct in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplex
+
+import (
+	"net/http"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	listerv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// serviceCacheURL is cached url
+	ServiceCacheURL = "/api/v1/services"
+)
+
+func init() {
+	RegisterMuxFactory(ServiceCacheURL, &serviceCacheMuxFactory{})
+}
+
+type serviceCacheMuxFactory struct{}
+
+var _ CacheMuxFactory = &serviceCacheMuxFactory{}
+
+func (f *serviceCacheMuxFactory) Create(hostname string, informerFactory informers.SharedInformerFactory) (CacheMux, error) {
+	return NewServiceMux(hostname, informerFactory)
+}
+
+type serviceMux struct {
+	hostname    string
+	broadcaster *watch.Broadcaster
+	svcInformer cache.SharedIndexInformer
+	svcLister   listerv1.ServiceLister
+}
+
+var _ CacheMux = &serviceMux{}
+
+// NewserviceMux ...
+func NewServiceMux(hostname string, informerFactory informers.SharedInformerFactory) (CacheMux, error) {
+	ba := watch.NewLongQueueBroadcaster(maxQueuedEvents, watch.DropIfChannelFull)
+	informer := informerFactory.Core().V1().Services()
+	svcMux := &serviceMux{
+		hostname:    hostname,
+		broadcaster: ba,
+		svcInformer: informer.Informer(),
+		svcLister:   informer.Lister(),
+	}
+	// don't resync to downstream watchers
+	informer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+		AddFunc:    svcMux.OnAdd,
+		UpdateFunc: svcMux.OnUpdate,
+		DeleteFunc: svcMux.OnDelete,
+	}, 0)
+
+	// run with informerFactory
+
+	// stop := make(chan struct{})
+	// go informer.Informer().Run(stop)
+	// if !cache.WaitForNamedCacheSync("serviceMux", stop, informer.Informer().HasSynced) {
+	// 	return nil, fmt.Errorf("can't sync informers")
+	// }
+
+	return svcMux, nil
+}
+
+func (em *serviceMux) Name() string {
+	return ServiceCacheURL
+}
+
+func (sm *serviceMux) Match(method, URLPath string) bool {
+	if method == http.MethodGet && strings.HasPrefix(URLPath, ServiceCacheURL) {
+		return true
+	}
+	return false
+}
+
+// watch will ignore resourceVersion and return all
+func (sm *serviceMux) Watch(bookmark bool, ResourceVersion string) (watch.Interface, error) {
+	// list all obj in all namespaces
+	svcs, err := sm.svcLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("List services error by service lister, will drop first, err %v", err)
+		return nil, err
+	}
+	// build ADD event
+	// TODO deal with resourceVersion param
+	evList := make([]watch.Event, 0, len(svcs))
+	for _, svc := range svcs {
+		evList = append(evList, watch.Event{Type: watch.Added, Object: svc})
+	}
+
+	// broadcast watch with prefix
+	return sm.broadcaster.WatchWithPrefix(evList), nil
+}
+
+func (sm *serviceMux) ListObjects(selector labels.Selector, appendFn cache.AppendFunc) error {
+	store := sm.svcInformer.GetStore()
+	return cache.ListAll(store, selector, appendFn)
+}
+
+func (sm *serviceMux) OnAdd(obj interface{}) {
+	svcs, ok := obj.(*v1.Service)
+	if !ok {
+		return
+	}
+	sm.broadcaster.Action(watch.Added, svcs)
+}
+
+func (sm *serviceMux) OnUpdate(oldObj interface{}, newObj interface{}) {
+	svcs, ok := newObj.(*v1.Service)
+	if !ok {
+		return
+	}
+	sm.broadcaster.Action(watch.Modified, svcs)
+}
+
+func (sm *serviceMux) OnDelete(obj interface{}) {
+	svcs, ok := obj.(*v1.Service)
+	if !ok {
+		return
+	}
+	sm.broadcaster.Action(watch.Deleted, svcs)
+}

--- a/pkg/lite-apiserver/server/multiplex/service_cache_test.go
+++ b/pkg/lite-apiserver/server/multiplex/service_cache_test.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2020 The SuperEdge Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file excsvct in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplex
+
+// Service cache mux is extremely same with Endpoint test

--- a/pkg/lite-apiserver/server/server.go
+++ b/pkg/lite-apiserver/server/server.go
@@ -23,24 +23,42 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/pprof"
+	"strconv"
+	"time"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/klog/v2"
 
+	"github.com/munnerz/goautoneg"
 	"github.com/superedge/superedge/cmd/lite-apiserver/app/options"
 	"github.com/superedge/superedge/pkg/lite-apiserver/cache"
 	"github.com/superedge/superedge/pkg/lite-apiserver/cert"
 	"github.com/superedge/superedge/pkg/lite-apiserver/config"
 	"github.com/superedge/superedge/pkg/lite-apiserver/proxy"
+	muxserver "github.com/superedge/superedge/pkg/lite-apiserver/server/multiplex"
 	"github.com/superedge/superedge/pkg/lite-apiserver/storage"
 	"github.com/superedge/superedge/pkg/lite-apiserver/transport"
+
 	"github.com/superedge/superedge/pkg/util"
+
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclientwatch "k8s.io/client-go/rest/watch"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// LiteServer ...
 type LiteServer struct {
 	ServerConfig *config.LiteServerConfig
 	stopCh       <-chan struct{}
 }
 
+// CreateServer ...
 func CreateServer(serverOptions *options.ServerRunOptions, stopCh <-chan struct{}) (*LiteServer, error) {
 
 	config, err := serverOptions.ApplyTo()
@@ -53,11 +71,12 @@ func CreateServer(serverOptions *options.ServerRunOptions, stopCh <-chan struct{
 	}, nil
 }
 
+// Run ...
 func (s *LiteServer) Run() error {
 
 	certChannel := make(chan string, 10)
 	transportChannel := make(chan string, 10)
-
+	stopCh := make(<-chan struct{})
 	// init cert manager
 	certManager := cert.NewCertManager(s.ServerConfig, certChannel)
 	err := certManager.Init()
@@ -87,6 +106,51 @@ func (s *LiteServer) Run() error {
 		return err
 	}
 
+	// create client and informer factory
+	restConfig, err := clientcmd.BuildConfigFromKubeconfigGetter("", func() (*clientcmdapi.Config, error) {
+		conf := s.generateKubeConfiguration()
+		return conf, nil
+	})
+	if err != nil {
+		klog.Errorf("clientcmd.BuildConfigFromKubeconfigGetter error: %v", err)
+		return err
+	}
+	// get kubelet cert common name for transport
+	var kubeletCertCommonName string
+	for cn := range certManager.GetCertMap() {
+		if cn != "" {
+			kubeletCertCommonName = cn
+			klog.V(5).Infof("kubelet cert CommonName %s", kubeletCertCommonName)
+			break
+		}
+	}
+	// replace restConfig transport
+	restConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		// use transportManager default transport, it can reload cert
+		return transportManager.GetTransport(kubeletCertCommonName)
+	})
+	restConfig.UserAgent = "lite-apiserver/mux"
+	kubeClient := kubernetes.NewForConfigOrDie(restConfig)
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(kubeClient, 0)
+
+	for _, url := range s.ServerConfig.URLMultiplexCache {
+		mux, err := muxserver.CreateMux(url, "", informerFactory)
+		if err != nil {
+			klog.Errorf("Create url %s Mux error: %v", url, err)
+			return err
+		}
+		muxserver.RegisterMux(url, mux)
+	}
+	if len(s.ServerConfig.URLMultiplexCache) > 0 {
+		informerFactory.Start(stopCh)
+		for t, hasSynced := range informerFactory.WaitForCacheSync(stopCh) {
+			if !hasSynced {
+				klog.Errorf("Sync informer %s cache failed", t.Name())
+				return err
+			}
+		}
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/", edgeServerHandler)
 	mux.HandleFunc("/debug/flags/v", util.UpdateLogLevel)
@@ -98,6 +162,11 @@ func (s *LiteServer) Run() error {
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 	}
 
+	handler := http.Handler(mux)
+	// check if url need cache multiplex
+	handler = s.interceptCacheMultiplex(handler)
+	handler = logger(handler)
+
 	caCrt, err := ioutil.ReadFile(s.ServerConfig.CAFile)
 	if err != nil {
 		klog.Errorf("Read ca file err: %v", err)
@@ -108,7 +177,7 @@ func (s *LiteServer) Run() error {
 
 	ser := &http.Server{
 		Addr:    fmt.Sprintf("127.0.0.1:%d", s.ServerConfig.Port),
-		Handler: mux,
+		Handler: handler,
 		TLSConfig: &tls.Config{
 			ClientCAs:  pool,
 			ClientAuth: tls.VerifyClientCertIfGiven,
@@ -122,4 +191,242 @@ func (s *LiteServer) Run() error {
 	<-s.stopCh
 	klog.Info("Received a program exit signal")
 	return nil
+}
+
+func logger(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		klog.Infof("method %s, request: %s", r.Method, r.URL.String())
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func (s *LiteServer) interceptCacheMultiplex(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// only cache for GET method
+		if r.Method != http.MethodGet {
+			handler.ServeHTTP(w, r)
+			return
+		}
+
+		// get mux by url
+		mux, err := muxserver.GetMux(r.URL.Path)
+		if err != nil {
+			handler.ServeHTTP(w, r)
+			return
+		}
+		klog.V(4).Infof("Multiplex Cache URL %s use %s Mux, will return data from lite-apiserver, URL.Path is %s, User-Agent is %s",
+			mux.Name(), r.URL.String(), r.URL.Path, r.UserAgent())
+		queries := r.URL.Query()
+		acceptType := r.Header.Get("Accept")
+		info, found := parseAccept(acceptType, scheme.Codecs.SupportedMediaTypes())
+		if !found {
+			klog.Errorf("can't find %s serializer", acceptType)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		// get label from param
+		labelStr := queries.Get("labelSelector")
+		ls, err := labels.Parse(labelStr)
+		if err != nil {
+			klog.Errorf("invalid labelSelector parameter %s", labelStr)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		rv := queries.Get("resourceVersion")
+		var watchBookmarks bool
+		wbStr := queries.Get("allowWatchBookmarks")
+		if wbStr != "" {
+			watchBookmarks, err = strconv.ParseBool(wbStr)
+			if err != nil {
+				klog.Errorf("invalid allowWatchBookmarks parameter %s", wbStr)
+			}
+		}
+		encoder := scheme.Codecs.EncoderForVersion(info.Serializer, v1.SchemeGroupVersion)
+		// list request
+		if queries.Get("watch") == "" {
+			w.Header().Set("Content-Type", info.MediaType)
+			// list obj
+			var objList runtime.Object
+			switch r.URL.Path {
+			// k8s list will return xxxList object instead []xxx, so we must know query path
+			case muxserver.EndpointCacheURL:
+				var eps []*v1.Endpoints
+				err := mux.ListObjects(ls, func(m interface{}) {
+					eps = append(eps, m.(*v1.Endpoints))
+				})
+				if err != nil {
+					klog.Errorf("failed get resource list %v", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				epsItems := make([]v1.Endpoints, 0, len(eps))
+				for _, ep := range eps {
+					epsItems = append(epsItems, *ep)
+				}
+				// TODO build objectList and deal with fieldselector
+				objList = &v1.EndpointsList{
+					Items: epsItems,
+				}
+
+			case muxserver.NodeCacheURL:
+				var nodes []*v1.Node
+				err := mux.ListObjects(ls, func(m interface{}) {
+					nodes = append(nodes, m.(*v1.Node))
+				})
+				if err != nil {
+					klog.Errorf("failed get resource list %v", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				nodeItems := make([]v1.Node, 0, len(nodes))
+				for _, n := range nodes {
+					nodeItems = append(nodeItems, *n)
+				}
+				// TODO build objectList and deal with fieldselector
+				objList = &v1.NodeList{
+					Items: nodeItems,
+				}
+			case muxserver.ServiceCacheURL:
+				var svcs []*v1.Service
+				err := mux.ListObjects(ls, func(m interface{}) {
+					svcs = append(svcs, m.(*v1.Service))
+				})
+				if err != nil {
+					klog.Errorf("failed get resource list %v", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				svcItems := make([]v1.Service, 0, len(svcs))
+				for _, s := range svcs {
+					svcItems = append(svcItems, *s)
+				}
+				// TODO build objectList and deal with fieldselector
+				objList = &v1.ServiceList{
+					Items: svcItems,
+				}
+
+			}
+
+			err := encoder.Encode(objList, w)
+			if err != nil {
+				klog.Errorf("can't marshal resource list, %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			return
+		}
+
+		// cacheMux.Watch label and field selector
+		// watch request
+		timeoutSecondsStr := r.URL.Query().Get("timeoutSeconds")
+		timeout := time.Minute
+		if timeoutSecondsStr != "" {
+			timeout, _ = time.ParseDuration(fmt.Sprintf("%ss", timeoutSecondsStr))
+		}
+
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			klog.Errorf("unable to start watch - can't get http.Flusher: %#v", w)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		muxWatcher, err := mux.Watch(watchBookmarks, rv)
+		if err != nil {
+			klog.Errorf("unable to start mux watch: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		defer muxWatcher.Stop()
+		wacherChan := muxWatcher.ResultChan()
+
+		e := restclientwatch.NewEncoder(
+			streaming.NewEncoder(info.StreamSerializer.Framer.NewFrameWriter(w),
+				scheme.Codecs.EncoderForVersion(info.StreamSerializer, v1.SchemeGroupVersion)),
+			encoder)
+		if info.MediaType == runtime.ContentTypeProtobuf {
+			w.Header().Set("Content-Type", runtime.ContentTypeProtobuf+";stream=watch")
+		} else {
+			w.Header().Set("Content-Type", runtime.ContentTypeJSON)
+		}
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-timer.C:
+				return
+			case evt := <-wacherChan:
+				klog.V(5).Infof("Send watch event type: %+#v, event object %+#v", evt.Type, evt.Object)
+				err := e.Encode(&evt)
+				if err != nil {
+					klog.Errorf("can't encode watch event, %v", err)
+					return
+				}
+
+				if len(wacherChan) == 0 {
+					flusher.Flush()
+				}
+			}
+		}
+	})
+
+}
+func parseAccept(header string, accepted []runtime.SerializerInfo) (runtime.SerializerInfo, bool) {
+	if len(header) == 0 && len(accepted) > 0 {
+		return accepted[0], true
+	}
+
+	clauses := goautoneg.ParseAccept(header)
+	for i := range clauses {
+		clause := &clauses[i]
+		for i := range accepted {
+			accepts := &accepted[i]
+			switch {
+			case clause.Type == accepts.MediaTypeType && clause.SubType == accepts.MediaTypeSubType,
+				clause.Type == accepts.MediaTypeType && clause.SubType == "*",
+				clause.Type == "*" && clause.SubType == "*":
+				return *accepts, true
+			}
+		}
+	}
+
+	return runtime.SerializerInfo{}, false
+}
+
+func (s *LiteServer) generateKubeConfiguration() *clientcmdapi.Config {
+	clusters := make(map[string]*clientcmdapi.Cluster)
+	clusters["default-cluster"] = &clientcmdapi.Cluster{
+		Server:               fmt.Sprintf("https://%s:%d", s.ServerConfig.KubeApiserverUrl, s.ServerConfig.KubeApiserverPort),
+		CertificateAuthority: s.ServerConfig.CAFile,
+	}
+
+	contexts := make(map[string]*clientcmdapi.Context)
+	contexts["default-context"] = &clientcmdapi.Context{
+		Cluster:  "default-cluster",
+		AuthInfo: "default-user",
+	}
+
+	authinfos := make(map[string]*clientcmdapi.AuthInfo)
+	authinfos["default-user"] = &clientcmdapi.AuthInfo{
+		ClientKey:         s.ServerConfig.TLSConfig[0].KeyPath,
+		ClientCertificate: s.ServerConfig.TLSConfig[0].CertPath,
+	}
+
+	clientConfig := clientcmdapi.Config{
+		Kind:           "Config",
+		APIVersion:     "v1",
+		Clusters:       clusters,
+		Contexts:       contexts,
+		CurrentContext: "default-context",
+		AuthInfos:      authinfos,
+	}
+	return &clientConfig
 }


### PR DESCRIPTION

**What this PR does**:
The Superedge controller plane(apiserver, tunnel) was connected with edge node plane by public network, but there is some informer and controller which list and watch apiserver like kubelet, coredns, flanneld and application-grid-wrapper in every edge node. This will lead to many connections to apiserver and a log of downstream flow from apiserver of loadbalancer of apiserver. 
In this pr, we want to reuse the informer cache cross different controller by lite-apiserver.  In edge node lite-apiserver use kubelet cert and role to create informer listing and watching apiserver,  and other controller in same node can listing watching lite-apiserver instead of apiserver, it can reduce extensive repeat informer cache and direct contection to apiserver.
**Special notes for your reviewer**:

