### PR TITLE
Fix the bug of edge-health 

### DIFF
--- a/pkg/edge-health/check/check.go
+++ b/pkg/edge-health/check/check.go
@@ -17,16 +17,17 @@ limitations under the License.
 package check
 
 import (
+	"sync"
+
 	"github.com/superedge/superedge/pkg/edge-health/checkplugin"
 	"github.com/superedge/superedge/pkg/edge-health/common"
 	"github.com/superedge/superedge/pkg/edge-health/data"
 	"github.com/superedge/superedge/pkg/util"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog/v2"
-	"sync"
 )
 
 type Check interface {
@@ -72,7 +73,7 @@ func (c CheckEdge) GetNodeList() {
 		return
 	}
 
-	if config, err := ConfigMapManager.ConfigMapLister.ConfigMaps(util.NamespaceEdgeSystem).Get(common.TaintZoneConfig); err != nil { //multi-region cm not found
+	if config, err := ConfigMapManager.ConfigMapLister.ConfigMaps(util.PodNamespace).Get(common.TaintZoneConfig); err != nil { //multi-region cm not found
 		if apierrors.IsNotFound(err) {
 			if NodeList, err := NodeManager.NodeLister.List(masterSelector); err != nil {
 				klog.Errorf("config not exist, get nodes err: %v", err)

--- a/pkg/edge-health/util/util.go
+++ b/pkg/edge-health/util/util.go
@@ -22,22 +22,23 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
+
 	"github.com/superedge/superedge/pkg/edge-health/check"
 	"github.com/superedge/superedge/pkg/edge-health/common"
 	"github.com/superedge/superedge/pkg/edge-health/data"
 	"github.com/superedge/superedge/pkg/util"
 	"golang.org/x/sys/unix"
-	"io"
-	"k8s.io/api/core/v1"
-	"os"
-	"os/signal"
+	v1 "k8s.io/api/core/v1"
 )
 
 func GenerateHmac(communicatedata data.CommunicateData) (string, error) {
 	part1byte, _ := json.Marshal(communicatedata.SourceIP)
 	part2byte, _ := json.Marshal(communicatedata.ResultDetail)
 	hmacBefore := string(part1byte) + string(part2byte)
-	if hmacconf, err := check.ConfigMapManager.ConfigMapLister.ConfigMaps(util.NamespaceEdgeSystem).Get(common.HmacConfig); err != nil {
+	if hmacconf, err := check.ConfigMapManager.ConfigMapLister.ConfigMaps(util.PodNamespace).Get(common.HmacConfig); err != nil {
 		return "", err
 	} else {
 		return GetHmacCode(hmacBefore, hmacconf.Data[common.HmacKey])

--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -13,6 +13,8 @@ limitations under the License.
 
 package util
 
+import "os"
+
 //edgeadm
 const (
 	EdgeNodeLabelKey   = "superedge.io/node-edge"
@@ -42,4 +44,8 @@ const (
 const (
 	NamespaceEdgeSystem = "edge-system"
 	NamespaceKubePublic = "kube-public"
+)
+
+var (
+	PodNamespace = os.Getenv("POD_NAMESPACE")
 )


### PR DESCRIPTION
Edge-health use "NamespaceEdgeSystem" constant as the NS to get the required ConfigMap. But in public-cloud, there maybe no Namespace called "edge-system". So we need to get the Namespace dynamicly.

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**

**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

