### PR TITLE
Fix: lite-apiserver delete 'Accept' will lead some feature not work, …

### DIFF
--- a/pkg/lite-apiserver/constant/constant.go
+++ b/pkg/lite-apiserver/constant/constant.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package constant
 
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
 const (
 	FileStorage   = "file"
 	MemoryStorage = "memory"
@@ -38,6 +42,7 @@ const (
 )
 
 const (
-	Json = "application/json"
-	Yaml = "application/yaml"
+	Json     = runtime.ContentTypeJSON
+	Protobuf = runtime.ContentTypeProtobuf
+	Yaml     = runtime.ContentTypeYAML
 )


### PR DESCRIPTION


**What type of PR is this?**
Fix lite-apiserver delete 'Accept' will lead some feature not work. For example, when we need get 'PartialObjectMetadata' , it will set header like 'Accept: application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json', and we can't delete 'Accept' or we will gonna origin Object instead. 
**What this PR does**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

