### PR TITLE
fix(application-grid-wrapper): Solve the bug of service access failure

### DIFF
--- a/pkg/application-grid-wrapper/server/server.go
+++ b/pkg/application-grid-wrapper/server/server.go
@@ -209,8 +209,8 @@ func (s *interceptorServer) setupInformers(stop <-chan struct{}) error {
 
 	restMapperRes, err := restmapper.GetAPIGroupResources(client.Discovery())
 	if err != nil {
-		_, err = client.DiscoveryV1().EndpointSlices("").List(context.Background(), metav1.ListOptions{})
-		if err == nil {
+		epsv1, err := client.DiscoveryV1().EndpointSlices("").List(context.Background(), metav1.ListOptions{})
+		if err == nil && len(epsv1.Items) != 0 {
 			klog.Info("start v1.EndpointSlices informer")
 			endpointSliceV1Informer := informerFactory.Discovery().V1().EndpointSlices().Informer()
 			endpointSliceV1Informer.AddEventHandlerWithResyncPeriod(s.cache.EndpointSliceV1EventHandler(), resyncPeriod)
@@ -219,8 +219,8 @@ func (s *interceptorServer) setupInformers(stop <-chan struct{}) error {
 				return fmt.Errorf("can't sync endpointslice informers")
 			}
 		} else {
-			_, err = client.DiscoveryV1beta1().EndpointSlices("").List(context.Background(), metav1.ListOptions{})
-			if err == nil {
+			epsv1beta1, err := client.DiscoveryV1beta1().EndpointSlices("").List(context.Background(), metav1.ListOptions{})
+			if err == nil && len(epsv1beta1.Items) != 0 {
 				klog.Info("start v1beta1.EndpointSlices informer")
 				endpointSliceV1Beta1Informer := informerFactory.Discovery().V1beta1().EndpointSlices().Informer()
 				endpointSliceV1Beta1Informer.AddEventHandlerWithResyncPeriod(s.cache.EndpointSliceV1Beta1EventHandler(), resyncPeriod)


### PR DESCRIPTION

**What type of PR is this?**
kind/bug
**What this PR does**:
Solve the service access failure caused by watch v1.endpointSlice after restarting the edge node component wrapper of k8s 1.20 when the network is disconnected


