### PR TITLE
bugfix(application-grid-controller): processs next item after updatin…

### DIFF
--- a/pkg/application-grid-controller/controller/deployment/controller.go
+++ b/pkg/application-grid-controller/controller/deployment/controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/superedge/superedge/pkg/application-grid-controller/controller"
 	"github.com/superedge/superedge/pkg/application-grid-controller/controller/common"
 	"github.com/superedge/superedge/pkg/application-grid-controller/controller/deployment/util"
@@ -43,7 +45,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	klog "k8s.io/klog/v2"
-	"time"
 
 	crdv1 "github.com/superedge/superedge/pkg/application-grid-controller/apis/superedge.io/v1"
 
@@ -70,9 +71,9 @@ type DeploymentGridController struct {
 	kubeClient    clientset.Interface
 	crdClient     crdclientset.Interface
 
-	//focus on dg in parent cluster
+	// focus on dg in parent cluster
 	FedDeploymentGridController *FedDeploymentGridController
-	//parent cluster namespace
+	// parent cluster namespace
 	dedicatedNameSpace string
 
 	// To allow injection of syncDeploymentGrid for testing.
@@ -248,6 +249,7 @@ func (dgc *DeploymentGridController) syncDeploymentGrid(key string) error {
 		if err != nil && !errors.IsConflict(err) {
 			return err
 		}
+		return nil
 	}
 
 	// get deployment workload list of this grid
@@ -347,7 +349,7 @@ func (dgc *DeploymentGridController) updateDeploymentGrid(oldObj, newObj interfa
 	}
 	dgc.enqueueDeploymentGrid(curDg)
 
-	//deploymentGrid in same cluster
+	// deploymentGrid in same cluster
 	_, fed := curDg.Labels[common.FedrationKey]
 	_, dis := curDg.Labels[common.FedrationDisKey]
 	if fed && dis {
@@ -357,7 +359,7 @@ func (dgc *DeploymentGridController) updateDeploymentGrid(oldObj, newObj interfa
 		}
 	}
 
-	//deploymentGrid in parent cluster
+	// deploymentGrid in parent cluster
 	if fed && !dis {
 		if dgc.FedDeploymentGridController != nil {
 			parentFedDg := dgc.getParentFedDeploymentGrid(curDg)

--- a/pkg/application-grid-controller/controller/statefulset/controller.go
+++ b/pkg/application-grid-controller/controller/statefulset/controller.go
@@ -17,15 +17,16 @@ limitations under the License.
 package statefulset
 
 import (
+	"context"
 	"fmt"
+	"time"
+
 	"github.com/superedge/superedge/pkg/application-grid-controller/controller"
 	"github.com/superedge/superedge/pkg/application-grid-controller/controller/common"
 	appsv1 "k8s.io/api/apps/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 
-	"context"
 	"k8s.io/klog/v2"
 
 	"github.com/superedge/superedge/pkg/application-grid-controller/generated/clientset/versioned/scheme"
@@ -226,6 +227,7 @@ func (ssgc *StatefulSetGridController) syncStatefulSetGrid(key string) error {
 		if err != nil && !errors.IsConflict(err) {
 			return err
 		}
+		return nil
 	}
 
 	// get statefulset workload list of this grid


### PR DESCRIPTION
…g current dg/ssg

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
kind/bug

**What this PR does**:
Controller Worker should return to process the next item after updating the current deploymentgrid/statefulsetgrid. deploymentgrid/statefulsetgrid is reset to empty when update failed, the following errors occurs when generating labelselector with an empty key named xx.spec.GridUniqKey.

> I0314 11:16:52.359189       1 controller.go:172] Error syncing statefulset grid xxx/xxx: invalid label key "": name part must be non-empty; name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')


**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

