### PR TITLE
bugfix(application-grid-controller): return the update result directl…

### DIFF
--- a/pkg/application-grid-controller/controller/deployment/controller.go
+++ b/pkg/application-grid-controller/controller/deployment/controller.go
@@ -245,11 +245,8 @@ func (dgc *DeploymentGridController) syncDeploymentGrid(key string) error {
 		!apiequality.Semantic.DeepEqual(dg.Spec.DefaultTemplateName, dgCopy.Spec.DefaultTemplateName) ||
 		!apiequality.Semantic.DeepEqual(dg.Spec.TemplatePool, dgCopy.Spec.TemplatePool) {
 		klog.Infof("Updating deploymentGrid %s/%s template", dgCopy.Namespace, dgCopy.Name)
-		dg, err = dgc.crdClient.SuperedgeV1().DeploymentGrids(dgCopy.Namespace).Update(context.TODO(), dgCopy, metav1.UpdateOptions{})
-		if err != nil && !errors.IsConflict(err) {
-			return err
-		}
-		return nil
+		_, err = dgc.crdClient.SuperedgeV1().DeploymentGrids(dgCopy.Namespace).Update(context.TODO(), dgCopy, metav1.UpdateOptions{})
+		return err
 	}
 
 	// get deployment workload list of this grid

--- a/pkg/application-grid-controller/controller/statefulset/controller.go
+++ b/pkg/application-grid-controller/controller/statefulset/controller.go
@@ -223,11 +223,8 @@ func (ssgc *StatefulSetGridController) syncStatefulSetGrid(key string) error {
 		!apiequality.Semantic.DeepEqual(ssg.Spec.DefaultTemplateName, ssgCopy.Spec.DefaultTemplateName) ||
 		!apiequality.Semantic.DeepEqual(ssg.Spec.TemplatePool, ssgCopy.Spec.TemplatePool) {
 		klog.Infof("Updating statefulsetGrid %s/%s template info", ssgCopy.Namespace, ssgCopy.Name)
-		ssg, err = ssgc.crdClient.SuperedgeV1().StatefulSetGrids(ssgCopy.Namespace).Update(context.TODO(), ssgCopy, metav1.UpdateOptions{})
-		if err != nil && !errors.IsConflict(err) {
-			return err
-		}
-		return nil
+		_, err = ssgc.crdClient.SuperedgeV1().StatefulSetGrids(ssgCopy.Namespace).Update(context.TODO(), ssgCopy, metav1.UpdateOptions{})
+		return err
 	}
 
 	// get statefulset workload list of this grid


### PR DESCRIPTION
…y, conflict event cannot be discarded

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
kind/bug
**What this PR does**:
Controller worker return the update result directly, conflict errors cannot be ignored, otherwise the required event will be discarded.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

