### PR TITLE
bugfix(application-grid-wrapper): wrapper add qps/burst, update endpo…

### DIFF
--- a/cmd/application-grid-wrapper/app/options/options.go
+++ b/cmd/application-grid-wrapper/app/options/options.go
@@ -21,6 +21,8 @@ import (
 )
 
 type Options struct {
+	QPS                              float32
+	Burst                            int
 	CAFile                           string
 	KeyFile                          string
 	CertFile                         string
@@ -37,6 +39,8 @@ type Options struct {
 
 func NewGridWrapperOptions() *Options {
 	return &Options{
+		QPS:               float32(1000),
+		Burst:             1000,
 		BindAddress:       "localhost:51006",
 		InsecureMode:      true,
 		NotifyChannelSize: 100,
@@ -51,6 +55,8 @@ func NewGridWrapperOptions() *Options {
 }
 
 func (sc *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.Float32Var(&sc.QPS, "kube-qps", sc.QPS, "kubeconfig qps setting")
+	fs.IntVar(&sc.Burst, "kube-burst", sc.Burst, "kubeconfig burst setting")
 	fs.StringVar(&sc.CAFile, "ca-file", sc.CAFile,
 		"Certificate Authority file for communication between wrapper and kube-proxy")
 	fs.StringVar(&sc.KeyFile, "key-file", sc.KeyFile, "Private key file for communication between wrapper and kube-proxy")

--- a/pkg/application-grid-wrapper/storage/endpoints_handler.go
+++ b/pkg/application-grid-wrapper/storage/endpoints_handler.go
@@ -100,12 +100,20 @@ func (eh *endpointsHandler) OnAdd(obj interface{}) {
 	eh.add(eps)
 }
 
-func (eh *endpointsHandler) OnUpdate(_, newObj interface{}) {
-	eps, ok := newObj.(*v1.Endpoints)
+func (eh *endpointsHandler) OnUpdate(oldObj, newObj interface{}) {
+	oldEps, ok := oldObj.(*v1.Endpoints)
 	if !ok {
 		return
 	}
-	eh.update(eps)
+	newEps, ok := newObj.(*v1.Endpoints)
+	if !ok {
+		return
+	}
+	if apiequality.Semantic.DeepEqual(oldEps.Subsets, newEps.Subsets) {
+		return
+	}
+
+	eh.update(newEps)
 }
 
 func (eh *endpointsHandler) OnDelete(obj interface{}) {


### PR DESCRIPTION
…ints eventhandler

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
kind/bug

**What this PR does**:
1. The k8s client currently uses the default QPS/Burst, which should be set to configurable QPS and Burst parameters. 
2. When endpoint eventHandler handles the endpoint update event,  it should return directly if endpoint subsets unchanged.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

