### PR TITLE
bugfix(tunnel-cloud): set qps for tunnel cloud clientset

### DIFF
--- a/cmd/tunnel/app/options/options.go
+++ b/cmd/tunnel/app/options/options.go
@@ -25,6 +25,8 @@ type TunnelOption struct {
 	TunnelConf *string
 	Kubeconfig *string
 	Debug      *bool
+	QPS        float32
+	Burst      int
 }
 
 func NewTunnelOption() *TunnelOption {
@@ -37,6 +39,8 @@ func NewTunnelOption() *TunnelOption {
 		TunnelConf: &c,
 		Kubeconfig: &k,
 		Debug:      &d,
+		QPS:        1000,
+		Burst:      1000,
 	}
 }
 func (option *TunnelOption) Addflag() (fsSet cliflag.NamedFlagSets) {
@@ -44,5 +48,7 @@ func (option *TunnelOption) Addflag() (fsSet cliflag.NamedFlagSets) {
 	fs.StringVar(option.TunnelMode, "m", *option.TunnelMode, "Specify the edge proxy or cloud proxy")
 	fs.StringVar(option.TunnelConf, "c", *option.TunnelConf, "Specify the configuration file path")
 	fs.StringVar(option.Kubeconfig, "k", *option.Kubeconfig, "Specify the kubeconfig")
+	fs.Float32Var(&option.QPS, "kube-qps", option.QPS, "kubeconfig qps setting")
+	fs.IntVar(&option.Burst, "kube-burst", option.Burst, "kubeconfig burst setting")
 	return
 }

--- a/pkg/tunnel/proxy/modules/stream/streammng/connect/route.go
+++ b/pkg/tunnel/proxy/modules/stream/streammng/connect/route.go
@@ -25,10 +25,10 @@ import (
 	"github.com/superedge/superedge/pkg/tunnel/proxy/common/indexers"
 	tunnelutil "github.com/superedge/superedge/pkg/tunnel/util"
 	"github.com/superedge/superedge/pkg/util"
-	"github.com/superedge/superedge/pkg/util/kubeclient"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/klog/v2"
@@ -48,12 +48,7 @@ type RouteCache struct {
 	UserServicesMap map[string]string
 }
 
-func SyncRoute(path string) {
-	userClient, err := kubeclient.GetInclusterClientSet(path)
-	if err != nil {
-		klog.ErrorS(err, "failed to get kubeClient")
-		return
-	}
+func SyncRoute(userClient kubernetes.Interface) {
 	id := os.Getenv(tunnelutil.POD_NAME)
 	lock, err := resourcelock.New(resourcelock.EndpointsResourceLock,
 		os.Getenv(tunnelutil.USER_NAMESPACE_ENV),

--- a/pkg/util/kubeclient/client.go
+++ b/pkg/util/kubeclient/client.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/wait"
-	restclient "k8s.io/client-go/rest"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	restclient "k8s.io/client-go/rest"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,8 +99,10 @@ func GetKubeConfig(kubeConfigPath string) (*restclient.Config, error) {
 	return config, nil
 }
 
-func GetInclusterClientSet(kubeConfigPath string) (*kubernetes.Clientset, error) {
+func GetInclusterClientSet(kubeConfigPath string, qps float32, burst int) (*kubernetes.Clientset, error) {
 	clientConfig, err := GetKubeConfig(kubeConfigPath)
+	clientConfig.QPS = qps
+	clientConfig.Burst = burst
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
kind/bug

**What this PR does**:
Client-go default qps value is 5, which should be set to an appropriate value.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

