### PR TITLE
bugfix(lite-apiserver): save decompressed gzip data as local list cac…

### DIFF
--- a/pkg/lite-apiserver/cache/cache_gzip.go
+++ b/pkg/lite-apiserver/cache/cache_gzip.go
@@ -1,0 +1,86 @@
+package cache
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"sync"
+)
+
+var gzipEncodePool = &sync.Pool{
+	New: func() interface{} {
+		gw, err := gzip.NewWriterLevel(nil, defaultGzipContentEncodingLevel)
+		if err != nil {
+			panic(err)
+		}
+		return gw
+	},
+}
+
+var bufferPool = &sync.Pool{
+	New: func() interface{} {
+		return &bytes.Buffer{}
+	},
+}
+
+const (
+	// defaultGzipContentEncodingLevel is set to 1 which uses least CPU compared to higher levels, yet offers
+	// similar compression ratios (off by at most 1.5x, but typically within 1.1x-1.3x). For further details see -
+	// https://github.com/kubernetes/kubernetes/issues/112296
+	defaultGzipContentEncodingLevel = 1
+	// defaultGzipThresholdBytes is compared to the size of the first write from the stream
+	// (usually the entire object), and if the size is smaller no gzipping will be performed
+	// if the client requests it.
+	defaultGzipThresholdBytes = 128 * 1024
+)
+
+// gzipEncode encode data to gzip
+func gzipEncode(in []byte) (out []byte, err error) {
+	writer := gzipEncodePool.Get().(*gzip.Writer)
+	defer func() {
+		writer.Reset(nil)
+		gzipEncodePool.Put(writer)
+	}()
+	buffer := bufferPool.Get().(*bytes.Buffer)
+	defer func() {
+		buffer.Reset()
+		bufferPool.Put(buffer)
+	}()
+
+	// reset writer
+	writer.Reset(buffer)
+	// write data
+	_, err = writer.Write(in)
+	if err != nil {
+		return out, err
+	}
+	writer.Flush()
+
+	err = writer.Close()
+	if err != nil {
+		return out, err
+	}
+	out = []byte(buffer.String())
+	return out, nil
+}
+
+// gzipDecode decode gzip data
+func gzipDecode(in []byte) (out []byte, err error) {
+	reader, err := gzip.NewReader(bytes.NewReader(in))
+	if err != nil {
+		return out, err
+	}
+	defer reader.Close()
+
+	buffer := bufferPool.Get().(*bytes.Buffer)
+	defer buffer.Reset()
+	defer bufferPool.Put(buffer)
+
+	_, err = io.Copy(buffer, reader)
+	if err != nil {
+		return
+	}
+
+	out = []byte(buffer.String())
+	return out, nil
+}

--- a/pkg/lite-apiserver/cache/cache_gzip_test.go
+++ b/pkg/lite-apiserver/cache/cache_gzip_test.go
@@ -1,0 +1,26 @@
+package cache
+
+import "testing"
+
+func BenchmarkGzip(t *testing.B) {
+	data := "gzip input data test test tttttttt"
+
+	// test encode
+	encodeData, err := gzipEncode([]byte(data))
+	if err != nil {
+		t.Fatalf("encode data to gzip format failed, err: %v", err)
+	}
+	t.Logf("gzip data: %v", string(encodeData))
+
+	// test decode
+	decodeData, err := gzipDecode(encodeData)
+	if err != nil {
+		t.Fatalf("decode gzip data failed, err: %v", err)
+	}
+
+	if data != string(decodeData) {
+		t.Fatalf("invalid decode data, expect: %s, decode: %s", data, string(decodeData))
+	}
+
+	t.Logf("decode data: %s", string(decodeData))
+}


### PR DESCRIPTION
…he, otherwise using watch obj to update the local list cache will be failed.

<!--
Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/superedge/superedge/blob/master/CONTRIBUTING.md
-->

**What type of PR is this?**
kind/bug

**What this PR does**:
In k8s,  if the response data size exceeds the threshold, it will be compressed into gzip format, the gzip data should be decompressed before use. To fix this issue, we save decompressed gzip data as local list cache, otherwise using watch obj to update the local list cache will fail.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

